### PR TITLE
IDE support

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -40,6 +40,10 @@
             # Eventually we will probably want to build these with haskell.nix.
             nativeBuildInputs = [ pkgs.cabal-install pkgs.hlint pkgs.haskellPackages.fourmolu ];
 
+            tools = {
+              haskell-language-server = {};  # Must use haskell.nix, because the compiler version should match
+            };
+
             additional = ps: [
               ps.plutus-ledger-api
             ];

--- a/hie.yaml
+++ b/hie.yaml
@@ -1,0 +1,2 @@
+cradle:
+  cabal:

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,7 @@
+(import (
+  fetchTarball {
+    url = "https://github.com/edolstra/flake-compat/archive/99f1c2157fba4bfe6211a321fd0ee43199025dbf.tar.gz";
+    sha256 = "0x2jn3vrawwv9xp15674wjz9pixwjyj3j771izayl962zziivbx2"; }
+) {
+  src =  ./.;
+}).shellNix


### PR DESCRIPTION
- add `shell.nix` for VSCode nix-env-selector which doesn't support flakes
- add HLS to nix-shell, as well the required hie.yaml

If caching becomes an issue, I'd suggest that we create a cachix account for Plutonomicon (or some other shared cache).