### PR TITLE
Add some builtin types + utilities for constructing and working with them

### DIFF
--- a/Plutarch/Builtin.hs
+++ b/Plutarch/Builtin.hs
@@ -73,6 +73,7 @@ hexDigitToWord8 :: HasCallStack => Char -> Word8
 hexDigitToWord8 = f . toLower
   where
     f '0' = 0
+    f '1' = 1
     f '2' = 2
     f '3' = 3
     f '4' = 4

--- a/Plutarch/Builtin.hs
+++ b/Plutarch/Builtin.hs
@@ -1,6 +1,7 @@
 module Plutarch.Builtin (PData (..), pfstBuiltin, psndBuiltin, pasConstr, preadByteStr, PBuiltinPair, PBuiltinList, PBuiltinByteString, PBuiltinString) where
 
 import qualified Data.ByteString as BS
+import qualified Data.Text as Txt
 import Data.Char (toLower)
 import Data.String (IsString (..))
 import Data.Word (Word8)
@@ -23,6 +24,12 @@ instance POrd PBuiltinByteString where
   x £<= y = punsafeBuiltin PLC.LessThanEqualsByteString £ x £ y
   x £< y = punsafeBuiltin PLC.LessThanByteString £ x £ y
 
+instance Semigroup (Term s PBuiltinByteString) where
+  x <> y = punsafeBuiltin PLC.AppendByteString £ x £ y
+
+instance Monoid (Term s PBuiltinByteString) where
+  mempty = punsafeConstant . PLC.Some $ PLC.ValueOf PLC.DefaultUniByteString BS.empty
+
 -- | Errors that may arise while using 'preadByteStr'.
 data ByteStringReadError = UnevenLength | InvalidHexDigit Char
   deriving stock (Eq, Ord, Read, Show)
@@ -42,10 +49,16 @@ preadByteStr = fmap (punsafeConstant . PLC.Some . PLC.ValueOf PLC.DefaultUniByte
 data PBuiltinString s
 
 instance IsString (Term s PBuiltinString) where
-  fromString = punsafeConstant . PLC.Some . PLC.ValueOf PLC.DefaultUniString . fromString
+  fromString = punsafeConstant . PLC.Some . PLC.ValueOf PLC.DefaultUniString . Txt.pack
 
 instance PEq PBuiltinString where
   x £== y = punsafeBuiltin PLC.EqualsString £ x £ y
+
+instance Semigroup (Term s PBuiltinString) where
+  x <> y = punsafeBuiltin PLC.AppendString £ x £ y
+
+instance Monoid (Term s PBuiltinString) where
+  mempty = punsafeConstant . PLC.Some $ PLC.ValueOf PLC.DefaultUniString Txt.empty
 
 data PData s
   = PDataConstr (Term s (PBuiltinPair PInteger (PBuiltinList PData)))

--- a/Plutarch/Builtin.hs
+++ b/Plutarch/Builtin.hs
@@ -1,4 +1,4 @@
-module Plutarch.Builtin (PData (..), pfstBuiltin, psndBuiltin, pasConstr, preadByteStr, PBuiltinPair, PBuiltinList, PBuiltinByteString, PBuiltinString) where
+module Plutarch.Builtin (PData (..), pfstBuiltin, psndBuiltin, pasConstr, phexByteStr, PBuiltinPair, PBuiltinList, PBuiltinByteString, PBuiltinString) where
 
 import qualified Data.ByteString as BS
 import Data.Char (toLower)
@@ -35,8 +35,8 @@ data ByteStringReadError = UnevenLength | InvalidHexDigit Char
   deriving stock (Eq, Ord, Read, Show)
 
 -- | Interpret a hex string as a PBuiltinByteString.
-preadByteStr :: String -> Either ByteStringReadError (Term s PBuiltinByteString)
-preadByteStr = fmap (punsafeConstant . PLC.Some . PLC.ValueOf PLC.DefaultUniByteString . BS.pack) . f
+phexByteStr :: String -> Either ByteStringReadError (Term s PBuiltinByteString)
+phexByteStr = fmap (punsafeConstant . PLC.Some . PLC.ValueOf PLC.DefaultUniByteString . BS.pack) . f
   where
     f "" = Right []
     f [_] = Left UnevenLength

--- a/Plutarch/Builtin.hs
+++ b/Plutarch/Builtin.hs
@@ -1,7 +1,8 @@
-module Plutarch.Builtin (PData (..), pfstBuiltin, psndBuiltin, pasConstr, preadByteStr, PBuiltinPair, PBuiltinList, PBuiltinByteString) where
+module Plutarch.Builtin (PData (..), pfstBuiltin, psndBuiltin, pasConstr, preadByteStr, PBuiltinPair, PBuiltinList, PBuiltinByteString, PBuiltinString) where
 
 import qualified Data.ByteString as BS
 import Data.Char (toLower)
+import Data.String (IsString (..))
 import Data.Word (Word8)
 import Plutarch (punsafeBuiltin, punsafeConstant)
 import Plutarch.Bool (PEq (..), POrd (..))
@@ -37,6 +38,14 @@ preadByteStr = fmap (punsafeConstant . PLC.Some . PLC.ValueOf PLC.DefaultUniByte
         <$> hexDigitToWord8 x
         <*> hexDigitToWord8 y
         <*> f rest
+
+data PBuiltinString s
+
+instance IsString (Term s PBuiltinString) where
+  fromString = punsafeConstant . PLC.Some . PLC.ValueOf PLC.DefaultUniString . fromString
+
+instance PEq PBuiltinString where
+  x £== y = punsafeBuiltin PLC.EqualsString £ x £ y
 
 data PData s
   = PDataConstr (Term s (PBuiltinPair PInteger (PBuiltinList PData)))

--- a/Plutarch/Builtin.hs
+++ b/Plutarch/Builtin.hs
@@ -5,6 +5,7 @@ import Data.Char (toLower)
 import Data.String (IsString (..))
 import qualified Data.Text as Txt
 import Data.Word (Word8)
+import GHC.Stack (HasCallStack)
 import Plutarch (punsafeBuiltin, punsafeConstant)
 import Plutarch.Bool (PEq (..), POrd (..))
 import Plutarch.Integer (PInteger)
@@ -30,21 +31,13 @@ instance Semigroup (Term s PBuiltinByteString) where
 instance Monoid (Term s PBuiltinByteString) where
   mempty = punsafeConstant . PLC.Some $ PLC.ValueOf PLC.DefaultUniByteString BS.empty
 
--- | Errors that may arise while using 'preadByteStr'.
-data ByteStringReadError = UnevenLength | InvalidHexDigit Char
-  deriving stock (Eq, Ord, Read, Show)
-
 -- | Interpret a hex string as a PBuiltinByteString.
-phexByteStr :: String -> Either ByteStringReadError (Term s PBuiltinByteString)
-phexByteStr = fmap (punsafeConstant . PLC.Some . PLC.ValueOf PLC.DefaultUniByteString . BS.pack) . f
+phexByteStr :: HasCallStack => String -> Term s PBuiltinByteString
+phexByteStr = punsafeConstant . PLC.Some . PLC.ValueOf PLC.DefaultUniByteString . BS.pack . f
   where
-    f "" = Right []
-    f [_] = Left UnevenLength
-    f (x : y : rest) =
-      (\a b s -> (a * 16 + b) : s)
-        <$> hexDigitToWord8 x
-        <*> hexDigitToWord8 y
-        <*> f rest
+    f "" = []
+    f [_] = error "UnevenLength"
+    f (x : y : rest) = (hexDigitToWord8 x * 16 + hexDigitToWord8 y) : f rest
 
 data PBuiltinString s
 
@@ -76,22 +69,22 @@ psndBuiltin = phoistAcyclic $ pforce . pforce . punsafeBuiltin $ PLC.SndPair
 pasConstr :: Term s (PData :--> PBuiltinPair PInteger (PBuiltinList PData))
 pasConstr = punsafeBuiltin PLC.UnConstrData
 
-hexDigitToWord8 :: Char -> Either ByteStringReadError Word8
+hexDigitToWord8 :: HasCallStack => Char -> Word8
 hexDigitToWord8 = f . toLower
   where
-    f '0' = Right 0
-    f '2' = Right 2
-    f '3' = Right 3
-    f '4' = Right 4
-    f '5' = Right 5
-    f '6' = Right 6
-    f '7' = Right 7
-    f '8' = Right 8
-    f '9' = Right 9
-    f 'a' = Right 10
-    f 'b' = Right 11
-    f 'c' = Right 12
-    f 'd' = Right 13
-    f 'e' = Right 14
-    f 'f' = Right 15
-    f c = Left $ InvalidHexDigit c
+    f '0' = 0
+    f '2' = 2
+    f '3' = 3
+    f '4' = 4
+    f '5' = 5
+    f '6' = 6
+    f '7' = 7
+    f '8' = 8
+    f '9' = 9
+    f 'a' = 10
+    f 'b' = 11
+    f 'c' = 12
+    f 'd' = 13
+    f 'e' = 14
+    f 'f' = 15
+    f c = error $ "InvalidHexDigit " ++ [c]

--- a/Plutarch/Builtin.hs
+++ b/Plutarch/Builtin.hs
@@ -1,9 +1,9 @@
 module Plutarch.Builtin (PData (..), pfstBuiltin, psndBuiltin, pasConstr, preadByteStr, PBuiltinPair, PBuiltinList, PBuiltinByteString, PBuiltinString) where
 
 import qualified Data.ByteString as BS
-import qualified Data.Text as Txt
 import Data.Char (toLower)
 import Data.String (IsString (..))
+import qualified Data.Text as Txt
 import Data.Word (Word8)
 import Plutarch (punsafeBuiltin, punsafeConstant)
 import Plutarch.Bool (PEq (..), POrd (..))

--- a/Plutarch/Builtin.hs
+++ b/Plutarch/Builtin.hs
@@ -1,6 +1,7 @@
 module Plutarch.Builtin (PData (..), pfstBuiltin, psndBuiltin, pasConstr, PBuiltinPair, PBuiltinList, PBuiltinByteString) where
 
 import Plutarch (punsafeBuiltin)
+import Plutarch.Bool (PEq (..), POrd (..))
 import Plutarch.Integer (PInteger)
 import Plutarch.Prelude
 import qualified PlutusCore as PLC
@@ -10,6 +11,13 @@ data PBuiltinPair (a :: k -> Type) (b :: k -> Type) (s :: k)
 data PBuiltinList (a :: k -> Type) (s :: k)
 
 data PBuiltinByteString s
+
+instance PEq PBuiltinByteString where
+  x £== y = punsafeBuiltin PLC.EqualsByteString £ x £ y
+
+instance POrd PBuiltinByteString where
+  x £<= y = punsafeBuiltin PLC.LessThanEqualsByteString £ x £ y
+  x £< y = punsafeBuiltin PLC.LessThanByteString £ x £ y
 
 data PData s
   = PDataConstr (Term s (PBuiltinPair PInteger (PBuiltinList PData)))

--- a/Plutarch/Unit.hs
+++ b/Plutarch/Unit.hs
@@ -1,0 +1,11 @@
+module Plutarch.Unit (PUnit (..)) where
+
+import Plutarch (POpaque, PlutusType (PInner, pcon', pmatch'), punsafeConstant)
+import qualified PlutusCore as PLC
+
+data PUnit s = PUnit
+
+instance PlutusType PUnit where
+  type PInner PUnit _ = POpaque
+  pcon' PUnit = punsafeConstant . PLC.Some $ PLC.ValueOf PLC.DefaultUniUnit ()
+  pmatch' _ f = f PUnit

--- a/examples/Main.hs
+++ b/examples/Main.hs
@@ -93,7 +93,7 @@ tests =
     , testCase "PBuiltinByteString :: 0x12 <> 0x34 == 0x1234" $
         expect $
           (phexByteStr "12" <> phexByteStr "34") £== phexByteStr "1234"
-    , testCase "PBuiltinByteString :: \"ab\" <> \"cd\" == \"abcd\"" $
+    , testCase "PBuiltinString :: \"ab\" <> \"cd\" == \"abcd\"" $
         expect $
           ("ab" <> "cd") £== ("abcd" :: Term s PBuiltinString)
     , testCase "PBuiltinByteString mempty" $ expect $ mempty £== phexByteStr ""

--- a/plutarch.cabal
+++ b/plutarch.cabal
@@ -84,6 +84,7 @@ library
     Plutarch.ScriptContext
     Plutarch.Evaluate
     Plutarch.Maybe
+    Plutarch.Unit
   build-depends:
     , base
     , plutus-core


### PR DESCRIPTION
* Add `PBuiltinString`, representing plutus core strings. Alongside instances and utilities for constructing terms of it.
* Add `PUnit`, representing plutus core unit. Alongside instances and utilities for constructing terms of it.
* Add `PEq` and `POrd` instances for `PBuiltinByteString`
* Add `preadByteStr` for reading hex strings as a `PBuiltinByteString` term.
* Add `Semigroup` and `Monoid` instances for `PBuiltinByteString` and `PBuiltinString` terms.

### Notes
* Should add some tests for these
* Probably add `PIsString`, `PSemigroup`, `PMonoid` typeclasses and use those instead.