### PR TITLE
Fix `IfThenElse` not forcing sufficiently

### DIFF
--- a/Plutarch/Bool.hs
+++ b/Plutarch/Bool.hs
@@ -10,7 +10,7 @@ instance PlutusType PBool where
   type PInner PBool _ = POpaque
   pcon' PTrue = punsafeConstant . PLC.Some $ PLC.ValueOf PLC.DefaultUniBool True
   pcon' PFalse = punsafeConstant . PLC.Some $ PLC.ValueOf PLC.DefaultUniBool False
-  pmatch' b f = pforce $ (punsafeBuiltin PLC.IfThenElse) £ b £ (pdelay $ f PTrue) £ (pdelay $ f PFalse)
+  pmatch' b f = pforce $ pforce (punsafeBuiltin PLC.IfThenElse) £ b £ pdelay (f PTrue) £ pdelay (f PFalse)
 
 class PEq t where
   (£==) :: Term s t -> Term s t -> Term s PBool

--- a/examples/Main.hs
+++ b/examples/Main.hs
@@ -78,7 +78,8 @@ tests =
     , testCase "example1" $ (printTerm example1) @?= "(program 1.0.0 ((\\i0 -> addInteger (i1 12 32) (i1 5 4)) (\\i0 -> \\i0 -> addInteger (addInteger i2 i1) 1)))"
     , testCase "example2" $ (printTerm example2) @?= "(program 1.0.0 (\\i0 -> i1 (\\i0 -> addInteger i1 1) (\\i0 -> subtractInteger i1 1)))"
     , testCase "pfix" $ (printTerm pfix) @?= "(program 1.0.0 ((\\i0 -> i1) (\\i0 -> (\\i0 -> i2 (\\i0 -> i2 i2 i1)) (\\i0 -> i2 (\\i0 -> i2 i2 i1)))))"
-    , testCase "fib" $ (printTerm fib) @?= "(program 1.0.0 ((\\i0 -> (\\i0 -> i1) (i1 (\\i0 -> \\i0 -> force (ifThenElse (equalsInteger i1 0) (delay 0) (delay (force (ifThenElse (equalsInteger i1 1) (delay 1) (delay (addInteger (i2 (subtractInteger i1 1)) (i2 (subtractInteger i1 2))))))))))) (\\i0 -> (\\i0 -> i2 (\\i0 -> i2 i2 i1)) (\\i0 -> i2 (\\i0 -> i2 i2 i1)))))"
+    , testCase "fib" $ (printTerm fib) @?= "(program 1.0.0 ((\\i0 -> (\\i0 -> i1) (i1 (\\i0 -> \\i0 -> force (force ifThenElse (equalsInteger i1 0) (delay 0) (delay (force (force ifThenElse (equalsInteger i1 1) (delay 1) (delay (addInteger (i2 (subtractInteger i1 1)) (i2 (subtractInteger i1 2))))))))))) (\\i0 -> (\\i0 -> i2 (\\i0 -> i2 i2 i1)) (\\i0 -> i2 (\\i0 -> i2 i2 i1)))))"
+    , testCase "fib 9 == 34" $ equal (fib £ 9) (34 :: Term s PInteger)
     , testCase "uglyDouble" $ (printTerm uglyDouble) @?= "(program 1.0.0 (\\i0 -> addInteger i1 i1))"
     , testCase "1 + 2 == 3" $ equal (1 + 2 :: Term s PInteger) (3 :: Term s PInteger)
     , testCase "fails: perror" $ fails perror


### PR DESCRIPTION
```hs
test :: Term s PInteger
test = pif (pcon PTrue) 1 2

-- >>> eval test
-- Left (EvaluationException "An error has occurred:  error:\nA builtin received a term argument when something else was expected\nCaused by: (ifThenElse True)" "UnexpectedBuiltinTermArgumentMachineError")
-- >>> printTerm test
-- "(program 1.0.0 (force (ifThenElse True (delay 1) (delay 2))))"
```
`IfThenElse` was missing a force. Should be similar to- `! (! IfThenElse True (# 1) (# 2))`