### PR TITLE
Add some more utilities

### DIFF
--- a/Plutarch/Builtin.hs
+++ b/Plutarch/Builtin.hs
@@ -1,6 +1,21 @@
-module Plutarch.Builtin (PData (..), pfstBuiltin, psndBuiltin, pasConstr, PBuiltinPair, PBuiltinList) where
+module Plutarch.Builtin (
+  PData (..),
+  pheadBuiltin,
+  ptailBuiltin,
+  pnullBuiltin,
+  pfstBuiltin,
+  psndBuiltin,
+  pasConstr,
+  pasMap,
+  pasList,
+  pasInt,
+  pasByteStr,
+  PBuiltinPair,
+  PBuiltinList,
+) where
 
 import Plutarch (punsafeBuiltin)
+import Plutarch.Bool (PBool)
 import Plutarch.ByteString (PByteString)
 import Plutarch.Integer (PInteger)
 import Plutarch.Prelude
@@ -9,6 +24,15 @@ import qualified PlutusCore as PLC
 data PBuiltinPair (a :: k -> Type) (b :: k -> Type) (s :: k)
 
 data PBuiltinList (a :: k -> Type) (s :: k)
+
+pheadBuiltin :: Term s (PBuiltinList a :--> a)
+pheadBuiltin = phoistAcyclic $ pforce $ punsafeBuiltin PLC.HeadList
+
+ptailBuiltin :: Term s (PBuiltinList a :--> PBuiltinList a)
+ptailBuiltin = phoistAcyclic $ pforce $ punsafeBuiltin PLC.TailList
+
+pnullBuiltin :: Term s (PBuiltinList a :--> PBool)
+pnullBuiltin = phoistAcyclic $ pforce $ punsafeBuiltin PLC.NullList
 
 data PData s
   = PDataConstr (Term s (PBuiltinPair PInteger (PBuiltinList PData)))
@@ -25,3 +49,15 @@ psndBuiltin = phoistAcyclic $ pforce . pforce . punsafeBuiltin $ PLC.SndPair
 
 pasConstr :: Term s (PData :--> PBuiltinPair PInteger (PBuiltinList PData))
 pasConstr = punsafeBuiltin PLC.UnConstrData
+
+pasMap :: Term s (PData :--> PBuiltinList (PBuiltinPair PData PData))
+pasMap = punsafeBuiltin PLC.UnMapData
+
+pasList :: Term s (PData :--> PBuiltinList PData)
+pasList = punsafeBuiltin PLC.UnListData
+
+pasInt :: Term s (PData :--> PInteger)
+pasInt = punsafeBuiltin PLC.UnIData
+
+pasByteStr :: Term s (PData :--> PByteString)
+pasByteStr = punsafeBuiltin PLC.UnBData

--- a/Plutarch/ByteString.hs
+++ b/Plutarch/ByteString.hs
@@ -1,5 +1,6 @@
-module Plutarch.ByteString (PByteString, phexByteStr) where
+module Plutarch.ByteString (PByteString, phexByteStr, pbyteStr) where
 
+import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
 import Data.Char (toLower)
 import Data.Word (Word8)
@@ -31,6 +32,10 @@ phexByteStr = punsafeConstant . PLC.Some . PLC.ValueOf PLC.DefaultUniByteString 
     f "" = []
     f [_] = error "UnevenLength"
     f (x : y : rest) = (hexDigitToWord8 x * 16 + hexDigitToWord8 y) : f rest
+
+-- | Construct a PByteString term from a Haskell bytestring.
+pbyteStr :: ByteString -> Term s PByteString
+pbyteStr = punsafeConstant . PLC.Some . PLC.ValueOf PLC.DefaultUniByteString
 
 hexDigitToWord8 :: HasCallStack => Char -> Word8
 hexDigitToWord8 = f . toLower


### PR DESCRIPTION
* Add plutarch synonyms to `PLC.HeadList`, `PLC.TailList`, and `PLC.NullList` for working with built in lists.
* Add synonyms for the remaining `BuiltinData` deconstruction builtins.
* Add `pbyteStr` - for creating a `PByteString` term from `ByteString`.