### PR TITLE
Add some tests for UPLC behaviour

### DIFF
--- a/plutarch.cabal
+++ b/plutarch.cabal
@@ -112,3 +112,4 @@ test-suite examples
     , tasty
     , tasty-hunit
     , plutus-ledger-api
+    , plutus-core


### PR DESCRIPTION
Notably, it has become evident that lists are in fact
homogeneous, and that since no polymorphic `nil` exists,
it is entirely impossible to use built-in lists of functions.