### PR TITLE
Improve `plam` type inference

### DIFF
--- a/Plutarch.hs
+++ b/Plutarch.hs
@@ -1,4 +1,6 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 module Plutarch (
   (PI.:-->),
@@ -56,20 +58,31 @@ infixl 8 #
 (#$) = papp
 infixr 0 #$
 
--- TODO: Improve type inference when using plam
+class PLamN a b | a -> b where
+  plam :: a -> b
 
-class PLam (s :: k) (b :: Type) where
-  type PLamOut b :: (k -> Type)
-  plam :: forall (a :: k -> Type). (Term s a -> b) -> Term s (a :--> PLamOut b)
+-- FIXME: This piece of code doesn't work unless you do (_ :: Term _ _)
+{-
+f :: Term s ((a :--> b) :--> b :--> b)
+f = plam $ \f _ -> f # perror
+-}
 
-instance PLam s (Term s b) where
-  type PLamOut (Term s b) = b
-  plam :: forall a. (Term s a -> Term s b) -> Term s (a :--> b)
+instance {-# INCOHERENT #-} (a' ~ Term s a, b' ~ Term s b) => PLamN (a' -> b') (Term s (a :--> b)) where
   plam = plam'
 
-instance PLam s c => PLam s (Term s b -> c) where
-  type PLamOut (Term s b -> c) = b :--> PLamOut c
-  plam :: forall a. (Term s a -> Term s b -> c) -> Term s (a :--> b :--> PLamOut c)
+instance {-# INCOHERENT #-} (a' ~ Term s a, b' ~ Term s b, c' ~ Term s c) => PLamN (a' -> b' -> c') (Term s (a :--> b :--> c)) where
+  plam f = plam' $ \x -> plam (f x)
+
+instance {-# INCOHERENT #-} (a' ~ Term s a, b' ~ Term s b, c' ~ Term s c, d' ~ Term s d) => PLamN (a' -> b' -> c' -> d') (Term s (a :--> b :--> c :--> d)) where
+  plam f = plam' $ \x -> plam (f x)
+
+instance {-# INCOHERENT #-} (a' ~ Term s a, b' ~ Term s b, c' ~ Term s c, d' ~ Term s d, e' ~ Term s e) => PLamN (a' -> b' -> c' -> d' -> e') (Term s (a :--> b :--> c :--> d :--> e)) where
+  plam f = plam' $ \x -> plam (f x)
+
+instance {-# INCOHERENT #-} (a' ~ Term s a, b' ~ Term s b, c' ~ Term s c, d' ~ Term s d, e' ~ Term s e, f' ~ Term s f) => PLamN (a' -> b' -> c' -> d' -> e' -> f') (Term s (a :--> b :--> c :--> d :--> e :--> f)) where
+  plam f = plam' $ \x -> plam (f x)
+
+instance {-# INCOHERENT #-} (a' ~ Term s a, b' ~ Term s b, c' ~ Term s c, d' ~ Term s d, e' ~ Term s e, f' ~ Term s f, g' ~ Term s g) => PLamN (a' -> b' -> c' -> d' -> e' -> f' -> g') (Term s (a :--> b :--> c :--> d :--> e :--> f :--> g)) where
   plam f = plam' $ \x -> plam (f x)
 
 pinl :: Term s a -> (Term s a -> Term s b) -> Term s b

--- a/Plutarch/Either.hs
+++ b/Plutarch/Either.hs
@@ -5,13 +5,8 @@ import Plutarch.Prelude
 
 data PEither (a :: k -> Type) (b :: k -> Type) (s :: k) = PLeft (Term s a) | PRight (Term s b)
 
--- Why do we need this?
-plam2 :: (Term s a -> Term s b -> Term s c) -> Term s (a :--> b :--> c)
-plam2 = plam
-
 instance PlutusType (PEither a b) where
   type PInner (PEither a b) c = (a :--> c) :--> (b :--> c) :--> c
-  pcon' :: forall s. PEither a b s -> forall c. Term s ((a :--> c) :--> (b :--> c) :--> c)
-  pcon' (PLeft x) = plam2 $ \f _ -> f # x
+  pcon' (PLeft x) = plam $ \f (_ :: Term _ _) -> f # x
   pcon' (PRight y) = plam $ \_ g -> g # y
   pmatch' p f = p # (plam $ \x -> f . PLeft $ x) # (plam $ \y -> f . PRight $ y)

--- a/Plutarch/Maybe.hs
+++ b/Plutarch/Maybe.hs
@@ -1,3 +1,6 @@
+{-# LANGUAGE PartialTypeSignatures #-}
+{-# OPTIONS_GHC -Wno-partial-type-signatures #-}
+
 module Plutarch.Maybe (PMaybe (..)) where
 
 import Plutarch (PlutusType (PInner, pcon', pmatch'))
@@ -5,16 +8,9 @@ import Plutarch.Prelude
 
 data PMaybe (a :: k -> Type) (s :: k) = PJust (Term s a) | PNothing
 
--- Why do we need this?
-plam2 :: (Term s a -> Term s b -> Term s c) -> Term s (a :--> b :--> c)
-plam2 = plam
-
--- Why do we need this?
-plam1 :: (Term s a -> Term s b) -> Term s (a :--> b)
-plam1 = plam
-
 instance PlutusType (PMaybe a) where
   type PInner (PMaybe a) b = (a :--> b) :--> PDelayed b :--> b
-  pcon' (PJust x) = plam2 $ \f _ -> f # x
-  pcon' PNothing = plam2 $ \_ g -> pforce g
-  pmatch' x f = x # (plam1 $ \inner -> f (PJust inner)) # (pdelay $ f PNothing)
+  pcon' :: forall s. PMaybe a s -> forall b. Term s (PInner (PMaybe a) b)
+  pcon' (PJust x) = plam $ \f (_ :: Term _ _) -> f # x
+  pcon' PNothing = plam $ \_ g -> pforce g
+  pmatch' x f = x # (plam $ \inner -> f (PJust inner)) # (pdelay $ f PNothing)

--- a/examples/Main.hs
+++ b/examples/Main.hs
@@ -1,6 +1,4 @@
-{-# LANGUAGE PartialTypeSignatures #-}
 {-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
-{-# OPTIONS_GHC -Wno-partial-type-signatures #-}
 
 module Main (main) where
 

--- a/plutarch.cabal
+++ b/plutarch.cabal
@@ -16,6 +16,7 @@ common c
     LambdaCase
     TypeFamilies
     OverloadedStrings
+    PartialTypeSignatures
     -- poor man's GHC2021
     BangPatterns
     BinaryLiterals
@@ -66,6 +67,7 @@ common c
     -Wall -Wcompat -Wincomplete-uni-patterns -Wredundant-constraints
     -Wmissing-export-lists -Werror -Wincomplete-record-updates
     -Wmissing-deriving-strategies -Wno-name-shadowing
+    -Wno-partial-type-signatures
 
 library
   import: c


### PR DESCRIPTION
This is a partial fix of #2.

The following example still does not work unfortunately:
```haskell
f :: Term s ((a :--> b) :--> b :--> b)
f = plam $ \f _ -> f # perror
```

Making it `(_ :: Term _ _)` makes it type check.