### PR TITLE
optimisation: Do some η-reductions

### DIFF
--- a/examples/Main.hs
+++ b/examples/Main.hs
@@ -216,6 +216,14 @@ plutarchTests =
     , testCase "PAsData equality" $ do
         expect $ let dat = pdata @PInteger 42 in dat #== dat
         expect $ pnot #$ pdata (phexByteStr "12") #== pdata (phexByteStr "ab")
+    , testCase "λx y -> addInteger x y => addInteger" $
+        printTerm (plam $ \x y -> (x :: Term _ PInteger) + y) @?= "(program 1.0.0 addInteger)"
+    , testCase "λx y -> hoist (force mkCons) x y => force mkCons" $
+        printTerm (plam $ \x y -> (pforce $ punsafeBuiltin PLC.MkCons) # x # y) @?= "(program 1.0.0 (force mkCons))"
+    , testCase "λx y -> hoist mkCons x y => mkCons x y" $
+        printTerm (plam $ \x y -> (punsafeBuiltin PLC.MkCons) # x # y) @?= "(program 1.0.0 (\\i0 -> \\i0 -> mkCons i2 i1))"
+    , testCase "λx y -> hoist (λx y. x + y - y - x) x y => λx y. x + y - y - x" $
+        printTerm (plam $ \x y -> (phoistAcyclic $ plam $ \(x :: Term _ PInteger) y -> x + y - y - x) # x # y) @?= "(program 1.0.0 (\\i0 -> \\i0 -> subtractInteger (subtractInteger (addInteger i2 i1) i1) i2))"
     ]
 
 uplcTests :: TestTree


### PR DESCRIPTION
We take advantage of the previously introduced concept of "arities"
to determine when this optimisation is sound. Arity represents
how many arguments can be passed before the term is no longer in WHNF.

We can't η-reduce when the wrapping lambda has a higher arity, as
that would mean e.g. `\x y z -> f x y z` where `f = \_ -> perror` would be
optimised into `\_ -> perror` which has different behaviour.

We don't catch all cases, specifically, the `f` in `\x -> f x` must be
a hoisted term (therefore closed). It doesn't have to be this restricted,
but then we'd need per-level tracking of variable usage by terms, which is
certainly possible (and also useful for automatic hoisting / CSE) but not
something I'm going to do in this commit.

Fixes #32
