### PR TITLE
Ignore .direnv from git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /result*
 /dist-newstyle
+.direnv


### PR DESCRIPTION
I use https://github.com/nix-community/nix-direnv which creates a `./.direnv/`.