### PR TITLE
Add `pconstant` and `plift`

### DIFF
--- a/Plutarch.hs
+++ b/Plutarch.hs
@@ -19,7 +19,6 @@ module Plutarch (
   PI.plet,
   PI.punsafeBuiltin,
   PI.punsafeCoerce,
-  PI.punsafeConstant,
   PI.Term,
   PI.TermCont (..),
   PlutusType (..),

--- a/Plutarch.hs
+++ b/Plutarch.hs
@@ -21,6 +21,9 @@ module Plutarch (
   PI.punsafeCoerce,
   PI.Term,
   PI.TermCont (..),
+  PL.plift,
+  PL.pconstant,
+  PL.plift',
   PlutusType (..),
   printTerm,
   printScript,
@@ -41,6 +44,7 @@ module Plutarch (
 import Data.Kind (Type)
 import Plutarch.Internal (ClosedTerm, Term, compile, papp, phoistAcyclic, plam', punsafeCoerce, (:-->))
 import qualified Plutarch.Internal as PI
+import qualified Plutarch.Lift as PL
 import Plutus.V1.Ledger.Scripts (Script (Script))
 import PlutusCore.Pretty (prettyPlcReadableDebug)
 

--- a/Plutarch.hs
+++ b/Plutarch.hs
@@ -19,6 +19,7 @@ module Plutarch (
   PI.plet,
   PI.punsafeBuiltin,
   PI.punsafeCoerce,
+  PI.punsafeConstant,
   PI.Term,
   PI.TermCont (..),
   PL.plift,

--- a/Plutarch/Bool.hs
+++ b/Plutarch/Bool.hs
@@ -14,6 +14,7 @@ module Plutarch.Bool (
 ) where
 
 import Plutarch (PlutusType (PInner, pcon', pmatch'), punsafeBuiltin, punsafeConstant)
+import Plutarch.Lift
 import Plutarch.Prelude
 import qualified PlutusCore as PLC
 
@@ -36,6 +37,9 @@ class POrd t where
 
 infix 4 #<=
 infix 4 #<
+
+instance PDefaultUni PBool where
+  type PDefaultUniType PBool = Bool
 
 {- | Strict version of 'pif'.
  Emits slightly less code.

--- a/Plutarch/Bool.hs
+++ b/Plutarch/Bool.hs
@@ -1,3 +1,6 @@
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE UndecidableInstances #-}
+
 module Plutarch.Bool (
   PBool (..),
   PEq (..),
@@ -19,6 +22,7 @@ import Plutarch.Prelude
 import qualified PlutusCore as PLC
 
 data PBool s = PTrue | PFalse
+  deriving (PLift) via PBuiltinType PBool Bool
 
 instance PlutusType PBool where
   type PInner PBool _ = PBool
@@ -37,8 +41,6 @@ class POrd t where
 
 infix 4 #<=
 infix 4 #<
-
-type instance PDefaultUniType PBool = Bool
 
 {- | Strict version of 'pif'.
  Emits slightly less code.

--- a/Plutarch/Bool.hs
+++ b/Plutarch/Bool.hs
@@ -13,7 +13,7 @@ module Plutarch.Bool (
   por',
 ) where
 
-import Plutarch (PlutusType (PInner, pcon', pmatch'), punsafeBuiltin, punsafeConstant)
+import Plutarch (PlutusType (PInner, pcon', pmatch'), punsafeBuiltin)
 import Plutarch.Lift
 import Plutarch.Prelude
 import qualified PlutusCore as PLC
@@ -22,8 +22,8 @@ data PBool s = PTrue | PFalse
 
 instance PlutusType PBool where
   type PInner PBool _ = PBool
-  pcon' PTrue = punsafeConstant . PLC.Some $ PLC.ValueOf PLC.DefaultUniBool True
-  pcon' PFalse = punsafeConstant . PLC.Some $ PLC.ValueOf PLC.DefaultUniBool False
+  pcon' PTrue = pconstant True
+  pcon' PFalse = pconstant False
   pmatch' b f = pforce $ pif' # b # pdelay (f PTrue) # pdelay (f PFalse)
 
 class PEq t where

--- a/Plutarch/Bool.hs
+++ b/Plutarch/Bool.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Plutarch.Bool (

--- a/Plutarch/Bool.hs
+++ b/Plutarch/Bool.hs
@@ -38,8 +38,7 @@ class POrd t where
 infix 4 #<=
 infix 4 #<
 
-instance PDefaultUni PBool where
-  type PDefaultUniType PBool = Bool
+type instance PDefaultUniType PBool = Bool
 
 {- | Strict version of 'pif'.
  Emits slightly less code.

--- a/Plutarch/Builtin.hs
+++ b/Plutarch/Builtin.hs
@@ -18,10 +18,11 @@ module Plutarch.Builtin (
   PAsData,
 ) where
 
-import Plutarch (punsafeBuiltin, punsafeCoerce, punsafeConstant)
+import Plutarch (punsafeBuiltin, punsafeCoerce)
 import Plutarch.Bool (PBool, PEq, (#==))
 import Plutarch.ByteString (PByteString)
 import Plutarch.Integer (PInteger)
+import Plutarch.Lift (Lift (pconstant), PDefaultUni (..))
 import Plutarch.Prelude
 import qualified PlutusCore as PLC
 import PlutusTx (Data)
@@ -49,6 +50,9 @@ data PData s
 instance PEq PData where
   x #== y = punsafeBuiltin PLC.EqualsData # x # y
 
+instance PDefaultUni PData where
+  type PDefaultUniType PData = Data
+
 pfstBuiltin :: Term s (PBuiltinPair a b :--> a)
 pfstBuiltin = phoistAcyclic $ pforce . pforce . punsafeBuiltin $ PLC.FstPair
 
@@ -71,7 +75,7 @@ pasByteStr :: Term s (PData :--> PByteString)
 pasByteStr = punsafeBuiltin PLC.UnBData
 
 pdataLiteral :: Data -> Term s PData
-pdataLiteral = punsafeConstant . PLC.Some . PLC.ValueOf PLC.DefaultUniData
+pdataLiteral = pconstant
 
 data PAsData (a :: k -> Type) (s :: k)
 

--- a/Plutarch/Builtin.hs
+++ b/Plutarch/Builtin.hs
@@ -22,7 +22,7 @@ import Plutarch (punsafeBuiltin, punsafeCoerce)
 import Plutarch.Bool (PBool, PEq, (#==))
 import Plutarch.ByteString (PByteString)
 import Plutarch.Integer (PInteger)
-import Plutarch.Lift (Lift (pconstant), PDefaultUniType)
+import Plutarch.Lift
 import Plutarch.Prelude
 import qualified PlutusCore as PLC
 import PlutusTx (Data)

--- a/Plutarch/Builtin.hs
+++ b/Plutarch/Builtin.hs
@@ -77,6 +77,7 @@ pasInt = punsafeBuiltin PLC.UnIData
 pasByteStr :: Term s (PData :--> PByteString)
 pasByteStr = punsafeBuiltin PLC.UnBData
 
+{-# DEPRECATED pdataLiteral "Use `pconstant` instead." #-}
 pdataLiteral :: Data -> Term s PData
 pdataLiteral = pconstant
 

--- a/Plutarch/Builtin.hs
+++ b/Plutarch/Builtin.hs
@@ -16,17 +16,14 @@ module Plutarch.Builtin (
   pdataLiteral,
   PIsData (..),
   PAsData,
-  pconstantData,
-  pliftData,
 ) where
 
-import Plutarch (ClosedTerm, punsafeBuiltin, punsafeCoerce)
+import Plutarch (punsafeBuiltin, punsafeCoerce)
 import Plutarch.Bool (PBool, PEq, (#==))
 import Plutarch.ByteString (PByteString)
 import Plutarch.Integer (PInteger)
 import Plutarch.Lift
 import Plutarch.Prelude
-import qualified Plutus.V1.Ledger.Api as Ledger
 import qualified PlutusCore as PLC
 import PlutusTx (Data)
 
@@ -54,15 +51,6 @@ data PData s
   | PDataInteger (Term s PInteger)
   | PDataByteString (Term s PByteString)
 
-pconstantData :: forall k (p :: k -> Type) h (s :: k). Ledger.ToData h => h -> Term s p
-pconstantData = punsafeCoerce . pconstant @PData . Ledger.toData
-
-pliftData :: forall k (p :: k -> Type) h. Ledger.FromData h => ClosedTerm p -> Either LiftError h
-pliftData t = do
-  h <- plift' @PData (punsafeCoerce t)
-  maybeToRight "Failed to decode data" $ Ledger.fromData h
-  where
-    maybeToRight e = maybe (Left e) Right
 instance PEq PData where
   x #== y = punsafeBuiltin PLC.EqualsData # x # y
 

--- a/Plutarch/Builtin.hs
+++ b/Plutarch/Builtin.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 -- This should have been called Plutarch.Data...

--- a/Plutarch/Builtin.hs
+++ b/Plutarch/Builtin.hs
@@ -22,7 +22,7 @@ import Plutarch (punsafeBuiltin, punsafeCoerce)
 import Plutarch.Bool (PBool, PEq, (#==))
 import Plutarch.ByteString (PByteString)
 import Plutarch.Integer (PInteger)
-import Plutarch.Lift (Lift (pconstant), PDefaultUni (..))
+import Plutarch.Lift (Lift (pconstant), PDefaultUniType)
 import Plutarch.Prelude
 import qualified PlutusCore as PLC
 import PlutusTx (Data)
@@ -50,8 +50,7 @@ data PData s
 instance PEq PData where
   x #== y = punsafeBuiltin PLC.EqualsData # x # y
 
-instance PDefaultUni PData where
-  type PDefaultUniType PData = Data
+type instance PDefaultUniType PData = Data
 
 pfstBuiltin :: Term s (PBuiltinPair a b :--> a)
 pfstBuiltin = phoistAcyclic $ pforce . pforce . punsafeBuiltin $ PLC.FstPair

--- a/Plutarch/Builtin.hs
+++ b/Plutarch/Builtin.hs
@@ -31,6 +31,10 @@ data PBuiltinPair (a :: k -> Type) (b :: k -> Type) (s :: k)
 
 data PBuiltinList (a :: k -> Type) (s :: k)
 
+type instance PDefaultUniType (PBuiltinPair a b) = (PDefaultUniType a, PDefaultUniType b)
+
+type instance PDefaultUniType (PBuiltinList a) = [PDefaultUniType a]
+
 pheadBuiltin :: Term s (PBuiltinList a :--> a)
 pheadBuiltin = phoistAcyclic $ pforce $ punsafeBuiltin PLC.HeadList
 

--- a/Plutarch/ByteString.hs
+++ b/Plutarch/ByteString.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Plutarch.ByteString (

--- a/Plutarch/ByteString.hs
+++ b/Plutarch/ByteString.hs
@@ -1,3 +1,6 @@
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE UndecidableInstances #-}
+
 module Plutarch.ByteString (
   PByteString,
   phexByteStr,
@@ -21,6 +24,7 @@ import Plutarch.Prelude
 import qualified PlutusCore as PLC
 
 data PByteString s
+  deriving (PLift) via PBuiltinType PByteString ByteString
 
 instance PEq PByteString where
   x #== y = punsafeBuiltin PLC.EqualsByteString # x # y
@@ -34,8 +38,6 @@ instance Semigroup (Term s PByteString) where
 
 instance Monoid (Term s PByteString) where
   mempty = pconstant BS.empty
-
-type instance PDefaultUniType PByteString = ByteString
 
 -- | Interpret a hex string as a PByteString.
 phexByteStr :: HasCallStack => String -> Term s PByteString

--- a/Plutarch/ByteString.hs
+++ b/Plutarch/ByteString.hs
@@ -35,8 +35,7 @@ instance Semigroup (Term s PByteString) where
 instance Monoid (Term s PByteString) where
   mempty = pconstant BS.empty
 
-instance PDefaultUni PByteString where
-  type PDefaultUniType PByteString = ByteString
+type instance PDefaultUniType PByteString = ByteString
 
 -- | Interpret a hex string as a PByteString.
 phexByteStr :: HasCallStack => String -> Term s PByteString

--- a/Plutarch/ByteString.hs
+++ b/Plutarch/ByteString.hs
@@ -16,6 +16,7 @@ import GHC.Stack (HasCallStack)
 import Plutarch (punsafeBuiltin, punsafeConstant)
 import Plutarch.Bool (PEq, POrd, (#<), (#<=), (#==))
 import Plutarch.Integer (PInteger)
+import Plutarch.Lift
 import Plutarch.Prelude
 import qualified PlutusCore as PLC
 
@@ -33,6 +34,9 @@ instance Semigroup (Term s PByteString) where
 
 instance Monoid (Term s PByteString) where
   mempty = punsafeConstant . PLC.Some $ PLC.ValueOf PLC.DefaultUniByteString BS.empty
+
+instance PDefaultUni PByteString where
+  type PDefaultUniType PByteString = ByteString
 
 -- | Interpret a hex string as a PByteString.
 phexByteStr :: HasCallStack => String -> Term s PByteString

--- a/Plutarch/ByteString.hs
+++ b/Plutarch/ByteString.hs
@@ -45,6 +45,8 @@ phexByteStr = pconstant . BS.pack . f
     f [_] = error "UnevenLength"
     f (x : y : rest) = (hexDigitToWord8 x * 16 + hexDigitToWord8 y) : f rest
 
+{-# DEPRECATED pbyteStr "Use `pconstant` instead." #-}
+
 -- | Construct a PByteString term from a Haskell bytestring.
 pbyteStr :: ByteString -> Term s PByteString
 pbyteStr = pconstant

--- a/Plutarch/ByteString.hs
+++ b/Plutarch/ByteString.hs
@@ -13,7 +13,7 @@ import qualified Data.ByteString as BS
 import Data.Char (toLower)
 import Data.Word (Word8)
 import GHC.Stack (HasCallStack)
-import Plutarch (punsafeBuiltin, punsafeConstant)
+import Plutarch (punsafeBuiltin)
 import Plutarch.Bool (PEq, POrd, (#<), (#<=), (#==))
 import Plutarch.Integer (PInteger)
 import Plutarch.Lift
@@ -33,14 +33,14 @@ instance Semigroup (Term s PByteString) where
   x <> y = punsafeBuiltin PLC.AppendByteString # x # y
 
 instance Monoid (Term s PByteString) where
-  mempty = punsafeConstant . PLC.Some $ PLC.ValueOf PLC.DefaultUniByteString BS.empty
+  mempty = pconstant BS.empty
 
 instance PDefaultUni PByteString where
   type PDefaultUniType PByteString = ByteString
 
 -- | Interpret a hex string as a PByteString.
 phexByteStr :: HasCallStack => String -> Term s PByteString
-phexByteStr = punsafeConstant . PLC.Some . PLC.ValueOf PLC.DefaultUniByteString . BS.pack . f
+phexByteStr = pconstant . BS.pack . f
   where
     f "" = []
     f [_] = error "UnevenLength"
@@ -48,7 +48,7 @@ phexByteStr = punsafeConstant . PLC.Some . PLC.ValueOf PLC.DefaultUniByteString 
 
 -- | Construct a PByteString term from a Haskell bytestring.
 pbyteStr :: ByteString -> Term s PByteString
-pbyteStr = punsafeConstant . PLC.Some . PLC.ValueOf PLC.DefaultUniByteString
+pbyteStr = pconstant
 
 -----------------------------------------------------------
 -- The following functions should be import qualified. --

--- a/Plutarch/Integer.hs
+++ b/Plutarch/Integer.hs
@@ -1,8 +1,8 @@
 module Plutarch.Integer (PInteger, PIntegral (..)) where
 
-import Plutarch (punsafeBuiltin, punsafeConstant)
+import Plutarch (punsafeBuiltin)
 import Plutarch.Bool (PEq, POrd, pif, (#<), (#<=), (#==))
-import Plutarch.Lift (PDefaultUni (..))
+import Plutarch.Lift (Lift (pconstant), PDefaultUni (..))
 import Plutarch.Prelude
 import qualified PlutusCore as PLC
 
@@ -41,7 +41,7 @@ instance Num (Term s PInteger) where
         (x #<= 0)
         (-1)
         1
-  fromInteger n = punsafeConstant . PLC.Some $ PLC.ValueOf PLC.DefaultUniInteger n
+  fromInteger = pconstant
 
 instance PDefaultUni PInteger where
   type PDefaultUniType PInteger = Integer

--- a/Plutarch/Integer.hs
+++ b/Plutarch/Integer.hs
@@ -1,3 +1,6 @@
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE UndecidableInstances #-}
+
 module Plutarch.Integer (PInteger, PIntegral (..)) where
 
 import Plutarch (punsafeBuiltin)
@@ -7,6 +10,7 @@ import Plutarch.Prelude
 import qualified PlutusCore as PLC
 
 data PInteger s
+  deriving (PLift) via PBuiltinType PInteger Integer
 
 class PIntegral a where
   pdiv :: Term s (a :--> a :--> a)
@@ -42,5 +46,3 @@ instance Num (Term s PInteger) where
         (-1)
         1
   fromInteger = pconstant
-
-type instance PDefaultUniType PInteger = Integer

--- a/Plutarch/Integer.hs
+++ b/Plutarch/Integer.hs
@@ -2,7 +2,7 @@ module Plutarch.Integer (PInteger, PIntegral (..)) where
 
 import Plutarch (punsafeBuiltin)
 import Plutarch.Bool (PEq, POrd, pif, (#<), (#<=), (#==))
-import Plutarch.Lift (Lift (pconstant), PDefaultUni (..))
+import Plutarch.Lift (Lift (pconstant), PDefaultUniType)
 import Plutarch.Prelude
 import qualified PlutusCore as PLC
 
@@ -43,5 +43,4 @@ instance Num (Term s PInteger) where
         1
   fromInteger = pconstant
 
-instance PDefaultUni PInteger where
-  type PDefaultUniType PInteger = Integer
+type instance PDefaultUniType PInteger = Integer

--- a/Plutarch/Integer.hs
+++ b/Plutarch/Integer.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Plutarch.Integer (PInteger, PIntegral (..)) where

--- a/Plutarch/Integer.hs
+++ b/Plutarch/Integer.hs
@@ -2,7 +2,7 @@ module Plutarch.Integer (PInteger, PIntegral (..)) where
 
 import Plutarch (punsafeBuiltin)
 import Plutarch.Bool (PEq, POrd, pif, (#<), (#<=), (#==))
-import Plutarch.Lift (Lift (pconstant), PDefaultUniType)
+import Plutarch.Lift
 import Plutarch.Prelude
 import qualified PlutusCore as PLC
 

--- a/Plutarch/Integer.hs
+++ b/Plutarch/Integer.hs
@@ -2,6 +2,7 @@ module Plutarch.Integer (PInteger, PIntegral (..)) where
 
 import Plutarch (punsafeBuiltin, punsafeConstant)
 import Plutarch.Bool (PEq, POrd, pif, (#<), (#<=), (#==))
+import Plutarch.Lift (PDefaultUni (..))
 import Plutarch.Prelude
 import qualified PlutusCore as PLC
 
@@ -41,3 +42,6 @@ instance Num (Term s PInteger) where
         (-1)
         1
   fromInteger n = punsafeConstant . PLC.Some $ PLC.ValueOf PLC.DefaultUniInteger n
+
+instance PDefaultUni PInteger where
+  type PDefaultUniType PInteger = Integer

--- a/Plutarch/Internal.hs
+++ b/Plutarch/Internal.hs
@@ -1,4 +1,4 @@
-module Plutarch.Internal ((:-->), PDelayed, Term, plam', plet, papp, pdelay, pforce, phoistAcyclic, perror, punsafeCoerce, punsafeBuiltin, punsafeConstant, compile, ClosedTerm, Dig, hashTerm, hashOpenTerm, TermCont (..)) where
+module Plutarch.Internal ((:-->), PDelayed, Term, plam', plet, papp, pdelay, pforce, phoistAcyclic, perror, punsafeCoerce, punsafeBuiltin, punsafeConstant, punsafeConstantInternal, compile, ClosedTerm, Dig, hashTerm, hashOpenTerm, TermCont (..)) where
 
 import Crypto.Hash (Context, Digest, hashFinalize, hashInit, hashUpdate)
 import Crypto.Hash.Algorithms (Blake2b_160)
@@ -209,8 +209,12 @@ punsafeCoerce (Term x) = Term x
 punsafeBuiltin :: UPLC.DefaultFun -> Term s a
 punsafeBuiltin f = Term $ \_ -> mkTermRes $ RBuiltin f
 
+{-# DEPRECATED punsafeConstant "Use `pconstant` instead." #-}
 punsafeConstant :: Some (ValueOf PLC.DefaultUni) -> Term s a
-punsafeConstant c = Term $ \_ -> mkTermRes $ RConstant c
+punsafeConstant = punsafeConstantInternal
+
+punsafeConstantInternal :: Some (ValueOf PLC.DefaultUni) -> Term s a
+punsafeConstantInternal c = Term $ \_ -> mkTermRes $ RConstant c
 
 asClosedRawTerm :: ClosedTerm a -> TermResult
 asClosedRawTerm = flip asRawTerm 0

--- a/Plutarch/Lift.hs
+++ b/Plutarch/Lift.hs
@@ -10,13 +10,17 @@ module Plutarch.Lift (
 
 import Data.Bifunctor (first)
 import Data.Data (Proxy (Proxy))
+import Data.Kind (Type)
 import Data.Text
 import qualified Data.Text as T
 import GHC.Stack (HasCallStack)
-import Plutarch
 import Plutarch.Evaluate (evaluateScript)
-import Plutarch.Internal (punsafeConstant)
-import Plutarch.Prelude
+import Plutarch.Internal (
+  ClosedTerm,
+  Term,
+  compile,
+  punsafeConstant,
+ )
 import qualified Plutus.V1.Ledger.Scripts as Scripts
 import qualified PlutusCore as PLC
 import PlutusCore.Constant (readKnownSelf)

--- a/Plutarch/Lift.hs
+++ b/Plutarch/Lift.hs
@@ -1,8 +1,8 @@
 {-# LANGUAGE UndecidableInstances #-}
 
 module Plutarch.Lift (
-  Lift (..),
-  Unlift (..),
+  PConstant (..),
+  PLift (..),
   PDefaultUniType,
 ) where
 
@@ -24,7 +24,7 @@ import PlutusCore.Pretty (Pretty, PrettyConst)
 import qualified UntypedPlutusCore as UPLC
 import UntypedPlutusCore.Evaluation.Machine.Cek (CekUserError)
 
-class Lift p (h :: Type) where
+class PConstant p (h :: Type) where
   -- {-
   -- Create a Plutarch-level constant, from a Haskell value.
   --
@@ -33,7 +33,7 @@ class Lift p (h :: Type) where
   -- -}
   pconstant :: h -> Term s p
 
-class Unlift (h :: Type) p where
+class PLift (h :: Type) p where
   -- {-
   -- Convert a Plutarch term to the associated Haskell value. Fail otherwise.
   -- This will fully evaluate the arbitrary closed expression, and convert the
@@ -41,11 +41,11 @@ class Unlift (h :: Type) p where
   -- -}
   plift :: HasCallStack => ClosedTerm p -> h
 
-instance (PLC.DefaultUni `PLC.Contains` h, PDefaultUniType p ~ h) => Lift p h where
+instance (PLC.DefaultUni `PLC.Contains` h, PDefaultUniType p ~ h) => PConstant p h where
   pconstant =
     punsafeConstant . PLC.Some . PLC.ValueOf (PLC.knownUniOf (Proxy @h))
 
-instance PLC.KnownTypeIn PLC.DefaultUni (UPLC.Term PLC.DeBruijn PLC.DefaultUni PLC.DefaultFun ()) h => Unlift h p where
+instance PLC.KnownTypeIn PLC.DefaultUni (UPLC.Term PLC.DeBruijn PLC.DefaultUni PLC.DefaultFun ()) h => PLift h p where
   plift prog =
     case evaluateScript (compile prog) of
       Left e -> error $ show e

--- a/Plutarch/Lift.hs
+++ b/Plutarch/Lift.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Plutarch.Lift (
@@ -10,6 +11,7 @@ import Data.Data (Proxy (Proxy))
 import GHC.Stack (HasCallStack)
 import Plutarch
 import Plutarch.Evaluate (evaluateScript)
+import Plutarch.Internal (punsafeConstant)
 import Plutarch.Prelude
 import qualified Plutus.V1.Ledger.Scripts as Scripts
 import qualified PlutusCore as PLC

--- a/Plutarch/Lift.hs
+++ b/Plutarch/Lift.hs
@@ -48,7 +48,7 @@ data LiftError
 instance IsString LiftError where
   fromString = LiftError_Custom . T.pack
 
-class PLift p (h :: Type) where
+class PLift (h :: Type) p where
   -- {-
   -- Create a Plutarch-level constant, from a Haskell value.
   -- Example:
@@ -64,7 +64,7 @@ class PLift p (h :: Type) where
   plift' :: ClosedTerm p -> Either LiftError h
 
 -- | Like `plift'` but fails on error.
-plift :: (PLift p h, HasCallStack) => ClosedTerm p -> h
+plift :: (PLift h p, HasCallStack) => ClosedTerm p -> h
 plift prog = either (error . show) id $ plift' prog
 
 instance
@@ -73,7 +73,7 @@ instance
   , PLC.DefaultUni `PLC.Contains` h
   , PDefaultUniType p ~ h
   ) =>
-  PLift p h
+  PLift h p
   where
   pconstant =
     punsafeConstantInternal . PLC.Some . PLC.ValueOf (PLC.knownUniOf (Proxy @h))

--- a/Plutarch/Lift.hs
+++ b/Plutarch/Lift.hs
@@ -19,7 +19,7 @@ import Plutarch.Internal (
   ClosedTerm,
   Term,
   compile,
-  punsafeConstant,
+  punsafeConstantInternal,
  )
 import qualified Plutus.V1.Ledger.Scripts as Scripts
 import qualified PlutusCore as PLC
@@ -59,7 +59,7 @@ plift prog = either (error . show) id $ plift' prog
 
 instance (PLC.DefaultUni `PLC.Contains` h, PDefaultUniType p ~ h) => PConstant p h where
   pconstant =
-    punsafeConstant . PLC.Some . PLC.ValueOf (PLC.knownUniOf (Proxy @h))
+    punsafeConstantInternal . PLC.Some . PLC.ValueOf (PLC.knownUniOf (Proxy @h))
 
 instance PLC.KnownTypeIn PLC.DefaultUni (UPLC.Term PLC.DeBruijn PLC.DefaultUni PLC.DefaultFun ()) h => PLift h p where
   plift' prog =

--- a/Plutarch/Lift.hs
+++ b/Plutarch/Lift.hs
@@ -3,10 +3,15 @@
 module Plutarch.Lift (
   PConstant (..),
   PLift (..),
+  plift,
+  LiftError (..),
   PDefaultUniType,
 ) where
 
+import Data.Bifunctor (first)
 import Data.Data (Proxy (Proxy))
+import Data.Text
+import qualified Data.Text as T
 import GHC.Stack (HasCallStack)
 import Plutarch
 import Plutarch.Evaluate (evaluateScript)
@@ -20,7 +25,6 @@ import PlutusCore.Evaluation.Machine.Exception (
   EvaluationException,
   MachineError,
  )
-import PlutusCore.Pretty (Pretty, PrettyConst)
 import qualified UntypedPlutusCore as UPLC
 import UntypedPlutusCore.Evaluation.Machine.Cek (CekUserError)
 
@@ -33,31 +37,36 @@ class PConstant p (h :: Type) where
   -- -}
   pconstant :: h -> Term s p
 
+data LiftError
+  = LiftError_ScriptError Scripts.ScriptError
+  | LiftError_EvalException T.Text -- Using Text, because there is no Eq possible with DeBruijn naming.
+  deriving stock (Eq, Show)
+
 class PLift (h :: Type) p where
   -- {-
   -- Convert a Plutarch term to the associated Haskell value. Fail otherwise.
   -- This will fully evaluate the arbitrary closed expression, and convert the
   -- resulting value.
   -- -}
-  plift :: HasCallStack => ClosedTerm p -> h
+  plift' :: ClosedTerm p -> Either LiftError h
+
+plift :: (PLift h p, HasCallStack) => ClosedTerm p -> h
+plift prog = either (error . show) id $ plift' prog
 
 instance (PLC.DefaultUni `PLC.Contains` h, PDefaultUniType p ~ h) => PConstant p h where
   pconstant =
     punsafeConstant . PLC.Some . PLC.ValueOf (PLC.knownUniOf (Proxy @h))
 
 instance PLC.KnownTypeIn PLC.DefaultUni (UPLC.Term PLC.DeBruijn PLC.DefaultUni PLC.DefaultFun ()) h => PLift h p where
-  plift prog =
+  plift' prog =
     case evaluateScript (compile prog) of
-      Left e -> error $ show e
+      Left e -> Left $ LiftError_ScriptError e
       Right (_, _, Scripts.unScript -> UPLC.Program _ _ term) ->
-        either (error . showEvalException) id $
+        first (LiftError_EvalException . showEvalException) $
           readKnownSelf term
 
-showEvalException ::
-  (PLC.Everywhere uni PrettyConst, PLC.GShow uni, PLC.Closed uni, Pretty fun) =>
-  EvaluationException CekUserError (MachineError fun) (UPLC.Term UPLC.DeBruijn uni fun ()) ->
-  String
-showEvalException = show
+showEvalException :: EvaluationException CekUserError (MachineError PLC.DefaultFun) (UPLC.Term UPLC.DeBruijn PLC.DefaultUni PLC.DefaultFun ()) -> Text
+showEvalException = T.pack . show
 
 {- | Family of eDSL Types that map to Plutus builtin in its `DefaultUni`
 

--- a/Plutarch/Lift.hs
+++ b/Plutarch/Lift.hs
@@ -40,39 +40,46 @@ data LiftError
   | LiftError_EvalException T.Text -- Using Text, because there is no Eq possible with DeBruijn naming.
   deriving stock (Eq, Show)
 
-class PLift p (h :: Type) where
-  -- {-
-  -- Create a Plutarch-level constant, from a Haskell value.
-  -- Example:
-  -- > pconstant @PInteger 42
-  -- -}
-  pconstant :: h -> Term s p
-
-  -- {-
-  -- Convert a Plutarch term to the associated Haskell value. Fail otherwise.
-  -- This will fully evaluate the arbitrary closed expression, and convert the
-  -- resulting value.
-  -- -}
-  plift' :: ClosedTerm p -> Either LiftError h
-
-plift :: (PLift p h, HasCallStack) => ClosedTerm p -> h
+-- | Like `plift'` but fails on error.
+plift ::
+  forall p h.
+  ( PLC.KnownTypeIn PLC.DefaultUni (UPLC.Term PLC.DeBruijn PLC.DefaultUni PLC.DefaultFun ()) h
+  , PLC.DefaultUni `PLC.Contains` h
+  , PDefaultUniType p ~ h
+  , HasCallStack
+  ) =>
+  ClosedTerm p ->
+  h
 plift prog = either (error . show) id $ plift' prog
 
-instance
+-- {-
+-- Create a Plutarch-level constant, from a Haskell value.
+-- Example:
+-- > pconstant @PInteger 42
+-- -}
+pconstant :: forall p h s. (PLC.DefaultUni `PLC.Contains` h, PDefaultUniType p ~ h) => h -> Term s p
+pconstant =
+  punsafeConstantInternal . PLC.Some . PLC.ValueOf (PLC.knownUniOf (Proxy @h))
+
+-- {-
+-- Convert a Plutarch term to the associated Haskell value. Fail otherwise.
+-- This will fully evaluate the arbitrary closed expression, and convert the
+-- resulting value.
+-- -}
+plift' ::
+  forall p h.
   ( PLC.KnownTypeIn PLC.DefaultUni (UPLC.Term PLC.DeBruijn PLC.DefaultUni PLC.DefaultFun ()) h
   , PLC.DefaultUni `PLC.Contains` h
   , PDefaultUniType p ~ h
   ) =>
-  PLift p h
-  where
-  pconstant =
-    punsafeConstantInternal . PLC.Some . PLC.ValueOf (PLC.knownUniOf (Proxy @h))
-  plift' prog =
-    case evaluateScript (compile prog) of
-      Left e -> Left $ LiftError_ScriptError e
-      Right (_, _, Scripts.unScript -> UPLC.Program _ _ term) ->
-        first (LiftError_EvalException . showEvalException) $
-          readKnownSelf term
+  ClosedTerm p ->
+  Either LiftError h
+plift' prog =
+  case evaluateScript (compile prog) of
+    Left e -> Left $ LiftError_ScriptError e
+    Right (_, _, Scripts.unScript -> UPLC.Program _ _ term) ->
+      first (LiftError_EvalException . showEvalException) $
+        readKnownSelf term
 
 showEvalException :: EvaluationException CekUserError (MachineError PLC.DefaultFun) (UPLC.Term UPLC.DeBruijn PLC.DefaultUni PLC.DefaultFun ()) -> Text
 showEvalException = T.pack . show

--- a/Plutarch/Lift.hs
+++ b/Plutarch/Lift.hs
@@ -1,0 +1,55 @@
+{-# LANGUAGE UndecidableInstances #-}
+
+module Plutarch.Lift (
+  Lift (..),
+  Unlift (..),
+) where
+
+import Data.Data (Proxy (Proxy))
+import GHC.Stack (HasCallStack)
+import Plutarch
+import Plutarch.Evaluate (evaluateScript)
+import Plutarch.Prelude
+import qualified Plutus.V1.Ledger.Scripts as Scripts
+import qualified PlutusCore as PLC
+import PlutusCore.Constant (readKnownSelf)
+import qualified PlutusCore.Constant as PLC
+import PlutusCore.Evaluation.Machine.Exception (
+  EvaluationException,
+  MachineError,
+ )
+import PlutusCore.Pretty (Pretty, PrettyConst)
+import qualified UntypedPlutusCore as UPLC
+import UntypedPlutusCore.Evaluation.Machine.Cek (CekUserError)
+
+class Lift (h :: Type) p where
+  -- {-
+  -- Create a Plutarch-level constant, from a Haskell value.
+  -- -}
+  pconstant :: h -> Term s p
+
+class Unlift (h :: Type) p where
+  -- {-
+  -- Convert a Plutarch term to the associated Haskell value. Fail otherwise.
+  -- This will fully evaluate the arbitrary closed expression, and convert the
+  -- resulting value.
+  -- -}
+  plift :: HasCallStack => ClosedTerm p -> h
+
+instance UPLC.DefaultUni `PLC.Contains` h => Lift h p where
+  pconstant =
+    punsafeConstant . PLC.Some . PLC.ValueOf (PLC.knownUniOf (Proxy @h))
+
+instance PLC.KnownTypeIn PLC.DefaultUni (UPLC.Term PLC.DeBruijn PLC.DefaultUni PLC.DefaultFun ()) h => Unlift h p where
+  plift prog =
+    case evaluateScript (compile prog) of
+      Left e -> error $ show e
+      Right (_, _, Scripts.unScript -> UPLC.Program _ _ term) ->
+        either (error . showEvalException) id $
+          readKnownSelf term
+
+showEvalException ::
+  (PLC.Everywhere uni PrettyConst, PLC.GShow uni, PLC.Closed uni, Pretty fun) =>
+  EvaluationException CekUserError (MachineError fun) (UPLC.Term UPLC.DeBruijn uni fun ()) ->
+  String
+showEvalException = show

--- a/Plutarch/Lift.hs
+++ b/Plutarch/Lift.hs
@@ -3,6 +3,7 @@
 module Plutarch.Lift (
   Lift (..),
   Unlift (..),
+  PDefaultUni (..),
 ) where
 
 import Data.Data (Proxy (Proxy))
@@ -36,7 +37,7 @@ class Unlift (h :: Type) p where
   -- -}
   plift :: HasCallStack => ClosedTerm p -> h
 
-instance UPLC.DefaultUni `PLC.Contains` h => Lift h p where
+instance (PDefaultUni p, PDefaultUniType p ~ h) => Lift h p where
   pconstant =
     punsafeConstant . PLC.Some . PLC.ValueOf (PLC.knownUniOf (Proxy @h))
 
@@ -53,3 +54,10 @@ showEvalException ::
   EvaluationException CekUserError (MachineError fun) (UPLC.Term UPLC.DeBruijn uni fun ()) ->
   String
 showEvalException = show
+
+{- | Class of eDSL Types that map to Plutus builtin in its `DefaultUni`
+
+ We use this in: PLC.knownUniOf $ Proxy @(PDefaultUniType a)
+-}
+class PLC.DefaultUni `PLC.Contains` PDefaultUniType a => PDefaultUni (a :: k -> Type) where
+  type PDefaultUniType a :: Type

--- a/Plutarch/Lift.hs
+++ b/Plutarch/Lift.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Plutarch.Lift (
@@ -49,7 +48,7 @@ data LiftError
 instance IsString LiftError where
   fromString = LiftError_Custom . T.pack
 
-class PLift p (h :: Type) | p -> h where
+class PLift p (h :: Type) where
   -- {-
   -- Create a Plutarch-level constant, from a Haskell value.
   -- Example:

--- a/Plutarch/ScriptContext.hs
+++ b/Plutarch/ScriptContext.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 -- Must correspond to V1 of Plutus.

--- a/Plutarch/ScriptContext.hs
+++ b/Plutarch/ScriptContext.hs
@@ -4,8 +4,8 @@
 -- See https://staging.plutus.iohkdev.io/doc/haddock/plutus-ledger-api/html/Plutus-V1-Ledger-Api.html
 module Plutarch.ScriptContext (PScriptContext (..), PScriptPurpose (..), PTxInfo (..)) where
 
-import Plutarch (PMatch, POpaque, punsafeCoerce)
-import Plutarch.Builtin (PBuiltinList, PData, PIsData)
+import Plutarch (PMatch, POpaque)
+import Plutarch.Builtin (PBuiltinList, PIsData, pconstantData, pliftData)
 import Plutarch.DataRepr (DataReprHandlers (DRHCons, DRHNil), PDataList, PIsDataRepr, PIsDataReprInstances (PIsDataReprInstances), PIsDataReprRepr, pmatchDataRepr, pmatchRepr)
 import Plutarch.Lift
 import Plutarch.Prelude
@@ -44,12 +44,8 @@ data PScriptPurpose s
   deriving (PMatch, PIsData) via (PIsDataReprInstances PScriptPurpose)
 
 instance {-# OVERLAPPING #-} PLift PScriptPurpose Ledger.ScriptPurpose where
-  pconstant = punsafeCoerce . pconstant @PData . Ledger.toData
-  plift' t = do
-    h <- plift' @PData (punsafeCoerce t)
-    maybeToRight "Failed to decode data" $ Ledger.fromData h
-    where
-      maybeToRight e = maybe (Left e) Right
+  pconstant = pconstantData
+  plift' = pliftData
 
 instance PIsDataRepr PScriptPurpose where
   type PIsDataReprRepr PScriptPurpose = '[ '[POpaque], '[POpaque], '[POpaque], '[POpaque]]
@@ -59,6 +55,10 @@ instance PIsDataRepr PScriptPurpose where
 
 data PScriptContext s = PScriptContext (Term s (PDataList '[PTxInfo, PScriptPurpose]))
   deriving (PMatch, PIsData) via (PIsDataReprInstances PScriptContext)
+
+instance {-# OVERLAPPING #-} PLift PScriptContext Ledger.ScriptContext where
+  pconstant = pconstantData
+  plift' = pliftData
 
 instance PIsDataRepr PScriptContext where
   type PIsDataReprRepr PScriptContext = '[ '[PTxInfo, PScriptPurpose]]

--- a/Plutarch/ScriptContext.hs
+++ b/Plutarch/ScriptContext.hs
@@ -5,7 +5,7 @@
 module Plutarch.ScriptContext (PScriptContext (..), PScriptPurpose (..), PTxInfo (..)) where
 
 import Plutarch (PMatch, POpaque)
-import Plutarch.Builtin (PBuiltinList, PIsData, pconstantData, pliftData)
+import Plutarch.Builtin (PBuiltinList, PIsData)
 import Plutarch.DataRepr (DataReprHandlers (DRHCons, DRHNil), PDataList, PIsDataRepr, PIsDataReprInstances (PIsDataReprInstances), PIsDataReprRepr, pmatchDataRepr, pmatchRepr)
 import Plutarch.Lift
 import Plutarch.Prelude
@@ -41,11 +41,7 @@ data PScriptPurpose s
   | PSpending (Term s (PDataList '[POpaque]))
   | PRewarding (Term s (PDataList '[POpaque]))
   | PCertifying (Term s (PDataList '[POpaque]))
-  deriving (PMatch, PIsData) via (PIsDataReprInstances PScriptPurpose)
-
-instance {-# OVERLAPPING #-} PLift PScriptPurpose Ledger.ScriptPurpose where
-  pconstant = pconstantData
-  plift' = pliftData
+  deriving (PMatch, PIsData, PLift Ledger.ScriptPurpose) via (PIsDataReprInstances PScriptPurpose)
 
 instance PIsDataRepr PScriptPurpose where
   type PIsDataReprRepr PScriptPurpose = '[ '[POpaque], '[POpaque], '[POpaque], '[POpaque]]
@@ -54,11 +50,7 @@ instance PIsDataRepr PScriptPurpose where
       DRHCons (f . PMinting) $ DRHCons (f . PSpending) $ DRHCons (f . PRewarding) $ DRHCons (f . PCertifying) DRHNil
 
 data PScriptContext s = PScriptContext (Term s (PDataList '[PTxInfo, PScriptPurpose]))
-  deriving (PMatch, PIsData) via (PIsDataReprInstances PScriptContext)
-
-instance {-# OVERLAPPING #-} PLift PScriptContext Ledger.ScriptContext where
-  pconstant = pconstantData
-  plift' = pliftData
+  deriving (PMatch, PIsData, PLift Ledger.ScriptContext) via (PIsDataReprInstances PScriptContext)
 
 instance PIsDataRepr PScriptContext where
   type PIsDataReprRepr PScriptContext = '[ '[PTxInfo, PScriptPurpose]]

--- a/Plutarch/ScriptContext.hs
+++ b/Plutarch/ScriptContext.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 -- Must correspond to V1 of Plutus.
 -- See https://staging.plutus.iohkdev.io/doc/haddock/plutus-ledger-api/html/Plutus-V1-Ledger-Api.html
@@ -41,7 +42,7 @@ data PScriptPurpose s
   | PSpending (Term s (PDataList '[POpaque]))
   | PRewarding (Term s (PDataList '[POpaque]))
   | PCertifying (Term s (PDataList '[POpaque]))
-  deriving (PMatch, PIsData, PLift Ledger.ScriptPurpose) via (PIsDataReprInstances PScriptPurpose)
+  deriving (PMatch, PIsData, PLift) via (PIsDataReprInstances PScriptPurpose Ledger.ScriptPurpose)
 
 instance PIsDataRepr PScriptPurpose where
   type PIsDataReprRepr PScriptPurpose = '[ '[POpaque], '[POpaque], '[POpaque], '[POpaque]]
@@ -50,7 +51,7 @@ instance PIsDataRepr PScriptPurpose where
       DRHCons (f . PMinting) $ DRHCons (f . PSpending) $ DRHCons (f . PRewarding) $ DRHCons (f . PCertifying) DRHNil
 
 data PScriptContext s = PScriptContext (Term s (PDataList '[PTxInfo, PScriptPurpose]))
-  deriving (PMatch, PIsData, PLift Ledger.ScriptContext) via (PIsDataReprInstances PScriptContext)
+  deriving (PMatch, PIsData, PLift) via (PIsDataReprInstances PScriptContext Ledger.ScriptContext)
 
 instance PIsDataRepr PScriptContext where
   type PIsDataReprRepr PScriptContext = '[ '[PTxInfo, PScriptPurpose]]

--- a/Plutarch/String.hs
+++ b/Plutarch/String.hs
@@ -12,6 +12,7 @@ import qualified PlutusCore as PLC
 
 data PString s
 
+{-# DEPRECATED pfromText "Use `pconstant` instead." #-}
 pfromText :: Txt.Text -> Term s PString
 pfromText = pconstant
 

--- a/Plutarch/String.hs
+++ b/Plutarch/String.hs
@@ -35,5 +35,4 @@ pencodeUtf8 = punsafeBuiltin PLC.EncodeUtf8
 pdecodeUtf8 :: Term s (PByteString :--> PString)
 pdecodeUtf8 = punsafeBuiltin PLC.DecodeUtf8
 
-instance PDefaultUni PString where
-  type PDefaultUniType PString = Text
+type instance PDefaultUniType PString = Text

--- a/Plutarch/String.hs
+++ b/Plutarch/String.hs
@@ -1,10 +1,12 @@
 module Plutarch.String (PString, pfromText, pencodeUtf8, pdecodeUtf8) where
 
 import Data.String (IsString, fromString)
+import Data.Text (Text)
 import qualified Data.Text as Txt
 import Plutarch (punsafeBuiltin, punsafeConstant)
 import Plutarch.Bool (PEq, (#==))
 import Plutarch.ByteString (PByteString)
+import Plutarch.Lift
 import Plutarch.Prelude
 import qualified PlutusCore as PLC
 
@@ -32,3 +34,6 @@ pencodeUtf8 = punsafeBuiltin PLC.EncodeUtf8
 -- | Decode a 'PByteString' using UTF-8.
 pdecodeUtf8 :: Term s (PByteString :--> PString)
 pdecodeUtf8 = punsafeBuiltin PLC.DecodeUtf8
+
+instance PDefaultUni PString where
+  type PDefaultUniType PString = Text

--- a/Plutarch/String.hs
+++ b/Plutarch/String.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Plutarch.String (PString, pfromText, pencodeUtf8, pdecodeUtf8) where

--- a/Plutarch/String.hs
+++ b/Plutarch/String.hs
@@ -3,7 +3,7 @@ module Plutarch.String (PString, pfromText, pencodeUtf8, pdecodeUtf8) where
 import Data.String (IsString, fromString)
 import Data.Text (Text)
 import qualified Data.Text as Txt
-import Plutarch (punsafeBuiltin, punsafeConstant)
+import Plutarch (punsafeBuiltin)
 import Plutarch.Bool (PEq, (#==))
 import Plutarch.ByteString (PByteString)
 import Plutarch.Lift
@@ -13,10 +13,10 @@ import qualified PlutusCore as PLC
 data PString s
 
 pfromText :: Txt.Text -> Term s PString
-pfromText = punsafeConstant . PLC.Some . PLC.ValueOf PLC.DefaultUniString
+pfromText = pconstant
 
 instance IsString (Term s PString) where
-  fromString = punsafeConstant . PLC.Some . PLC.ValueOf PLC.DefaultUniString . Txt.pack
+  fromString = pconstant . Txt.pack
 
 instance PEq PString where
   x #== y = punsafeBuiltin PLC.EqualsString # x # y
@@ -25,7 +25,7 @@ instance Semigroup (Term s PString) where
   x <> y = punsafeBuiltin PLC.AppendString # x # y
 
 instance Monoid (Term s PString) where
-  mempty = punsafeConstant . PLC.Some $ PLC.ValueOf PLC.DefaultUniString Txt.empty
+  mempty = pconstant Txt.empty
 
 -- | Encode a 'PString' using UTF-8.
 pencodeUtf8 :: Term s (PString :--> PByteString)

--- a/Plutarch/String.hs
+++ b/Plutarch/String.hs
@@ -1,3 +1,6 @@
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE UndecidableInstances #-}
+
 module Plutarch.String (PString, pfromText, pencodeUtf8, pdecodeUtf8) where
 
 import Data.String (IsString, fromString)
@@ -11,6 +14,7 @@ import Plutarch.Prelude
 import qualified PlutusCore as PLC
 
 data PString s
+  deriving (PLift) via PBuiltinType PString Text
 
 {-# DEPRECATED pfromText "Use `pconstant` instead." #-}
 pfromText :: Txt.Text -> Term s PString
@@ -35,5 +39,3 @@ pencodeUtf8 = punsafeBuiltin PLC.EncodeUtf8
 -- | Decode a 'PByteString' using UTF-8.
 pdecodeUtf8 :: Term s (PByteString :--> PString)
 pdecodeUtf8 = punsafeBuiltin PLC.DecodeUtf8
-
-type instance PDefaultUniType PString = Text

--- a/Plutarch/Unit.hs
+++ b/Plutarch/Unit.hs
@@ -1,3 +1,6 @@
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE UndecidableInstances #-}
+
 module Plutarch.Unit (PUnit (..)) where
 
 import Plutarch (PlutusType (PInner, pcon', pmatch'), Term, pcon)
@@ -5,6 +8,7 @@ import Plutarch.Bool (PBool (PFalse, PTrue), PEq, POrd, (#<), (#<=), (#==))
 import Plutarch.Lift
 
 data PUnit s = PUnit
+  deriving (PLift) via PBuiltinType PUnit ()
 
 instance PlutusType PUnit where
   type PInner PUnit _ = PUnit
@@ -23,5 +27,3 @@ instance Semigroup (Term s PUnit) where
 
 instance Monoid (Term s PUnit) where
   mempty = pcon PUnit
-
-type instance PDefaultUniType PUnit = ()

--- a/Plutarch/Unit.hs
+++ b/Plutarch/Unit.hs
@@ -1,15 +1,14 @@
 module Plutarch.Unit (PUnit (..)) where
 
-import Plutarch (POpaque, PlutusType (PInner, pcon', pmatch'), Term, pcon, punsafeConstant)
+import Plutarch (PlutusType (PInner, pcon', pmatch'), Term, pcon)
 import Plutarch.Bool (PBool (PFalse, PTrue), PEq, POrd, (#<), (#<=), (#==))
 import Plutarch.Lift
-import qualified PlutusCore as PLC
 
 data PUnit s = PUnit
 
 instance PlutusType PUnit where
-  type PInner PUnit _ = POpaque
-  pcon' PUnit = punsafeConstant . PLC.Some $ PLC.ValueOf PLC.DefaultUniUnit ()
+  type PInner PUnit _ = PUnit
+  pcon' PUnit = pconstant ()
   pmatch' _ f = f PUnit
 
 instance PEq PUnit where

--- a/Plutarch/Unit.hs
+++ b/Plutarch/Unit.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Plutarch.Unit (PUnit (..)) where

--- a/Plutarch/Unit.hs
+++ b/Plutarch/Unit.hs
@@ -2,6 +2,7 @@ module Plutarch.Unit (PUnit (..)) where
 
 import Plutarch (POpaque, PlutusType (PInner, pcon', pmatch'), Term, pcon, punsafeConstant)
 import Plutarch.Bool (PBool (PFalse, PTrue), PEq, POrd, (#<), (#<=), (#==))
+import Plutarch.Lift
 import qualified PlutusCore as PLC
 
 data PUnit s = PUnit
@@ -23,3 +24,6 @@ instance Semigroup (Term s PUnit) where
 
 instance Monoid (Term s PUnit) where
   mempty = pcon PUnit
+
+instance PDefaultUni PUnit where
+  type PDefaultUniType PUnit = ()

--- a/Plutarch/Unit.hs
+++ b/Plutarch/Unit.hs
@@ -24,5 +24,4 @@ instance Semigroup (Term s PUnit) where
 instance Monoid (Term s PUnit) where
   mempty = pcon PUnit
 
-instance PDefaultUni PUnit where
-  type PDefaultUniType PUnit = ()
+type instance PDefaultUniType PUnit = ()

--- a/examples/Main.hs
+++ b/examples/Main.hs
@@ -116,9 +116,9 @@ plutarchTests =
     , testCase "example2" $ (printTerm example2) @?= "(program 1.0.0 (\\i0 -> i1 (\\i0 -> addInteger i1 1) (\\i0 -> subtractInteger i1 1)))"
     , testCase "pfix" $ (printTerm pfix) @?= "(program 1.0.0 (\\i0 -> (\\i0 -> i2 (\\i0 -> i2 i2 i1)) (\\i0 -> i2 (\\i0 -> i2 i2 i1))))"
     , testCase "fib" $ (printTerm fib) @?= "(program 1.0.0 ((\\i0 -> (\\i0 -> (\\i0 -> i2 (\\i0 -> i2 i2 i1)) (\\i0 -> i2 (\\i0 -> i2 i2 i1))) (\\i0 -> \\i0 -> force (i3 (equalsInteger i1 0) (delay 0) (delay (force (i3 (equalsInteger i1 1) (delay 1) (delay (addInteger (i2 (subtractInteger i1 1)) (i2 (subtractInteger i1 2)))))))))) (force ifThenElse)))"
-    , testCase "fib 9 == 34" $ equal (fib # 9) (pconstant @PInteger 34)
+    , testCase "fib 9 == 34" $ equal (fib # 9) (pconstant @_ @PInteger 34)
     , testCase "uglyDouble" $ (printTerm uglyDouble) @?= "(program 1.0.0 (\\i0 -> addInteger i1 i1))"
-    , testCase "1 + 2 == 3" $ equal (pconstant @PInteger $ 1 + 2) (pconstant @PInteger 3)
+    , testCase "1 + 2 == 3" $ equal (pconstant @_ @PInteger $ 1 + 2) (pconstant @_ @PInteger 3)
     , testCase "fails: perror" $ fails perror
     , testCase "pnot" $ do
         (pnot #$ pcon PTrue) `equal` pcon PFalse
@@ -132,40 +132,40 @@ plutarchTests =
     , testCase "() <= () == True" $ do
         expect $ pcon PUnit #<= pcon PUnit
     , testCase "0x02af == 0x02af" $ expect $ phexByteStr "02af" #== phexByteStr "02af"
-    , testCase "\"foo\" == \"foo\"" $ expect $ "foo" #== pconstant @PString "foo"
+    , testCase "\"foo\" == \"foo\"" $ expect $ "foo" #== pconstant @_ @PString "foo"
     , testCase "PByteString :: mempty <> a == a <> mempty == a" $ do
         expect $ let a = phexByteStr "152a" in (mempty <> a) #== a
         expect $ let a = phexByteStr "4141" in (a <> mempty) #== a
     , testCase "PString :: mempty <> a == a <> mempty == a" $ do
-        expect $ let a = pconstant @PString "foo" in (mempty <> a) #== a
-        expect $ let a = pconstant @PString "bar" in (a <> mempty) #== a
+        expect $ let a = pconstant @_ @PString "foo" in (mempty <> a) #== a
+        expect $ let a = pconstant @_ @PString "bar" in (a <> mempty) #== a
     , testCase "PByteString :: 0x12 <> 0x34 == 0x1234" $
         expect $
           (phexByteStr "12" <> phexByteStr "34") #== phexByteStr "1234"
     , testCase "PString :: \"ab\" <> \"cd\" == \"abcd\"" $
         expect $
-          ("ab" <> "cd") #== (pconstant @PString "abcd")
+          ("ab" <> "cd") #== (pconstant @_ @PString "abcd")
     , testCase "PByteString mempty" $ expect $ mempty #== phexByteStr ""
     , testCase "pconsByteStr" $
         let xs = "5B1F"; b = "41"
          in (pconsBS # fromInteger (readByte b) # phexByteStr xs) `equal` phexByteStr (b <> xs)
     , testCase "plengthByteStr" $ do
-        (plengthBS # phexByteStr "012f") `equal` pconstant @PInteger 2
+        (plengthBS # phexByteStr "012f") `equal` pconstant @_ @PInteger 2
         expect $ (plengthBS # phexByteStr "012f") #== 2
         let xs = phexByteStr "48fCd1"
         (plengthBS #$ pconsBS # 91 # xs)
           `equal` (1 + plengthBS # xs)
     , testCase "pindexByteStr" $
-        (pindexBS # phexByteStr "4102af" # 1) `equal` pconstant @PInteger 0x02
+        (pindexBS # phexByteStr "4102af" # 1) `equal` pconstant @_ @PInteger 0x02
     , testCase "psliceByteStr" $
         (psliceBS # 1 # 3 # phexByteStr "4102afde5b2a") `equal` phexByteStr "02afde"
     , testCase "pconstant - phexByteStr relation" $ do
         let a = ["42", "ab", "df", "c9"]
-        pconstant @PByteString (BS.pack $ map readByte a) `equal` phexByteStr (concat a)
-    , testCase "PString mempty" $ expect $ mempty #== pconstant @PString ""
+        pconstant @_ @PByteString (BS.pack $ map readByte a) `equal` phexByteStr (concat a)
+    , testCase "PString mempty" $ expect $ mempty #== pconstant @_ @PString ""
     , testCase "pconstant \"abc\" == \"abc\"" $ do
-        pconstant @PString "abc" `equal` pconstant @PString "abc"
-        expect $ pconstant @PString "foo" #== "foo"
+        pconstant @_ @PString "abc" `equal` pconstant @_ @PString "abc"
+        expect $ pconstant @_ @PString "foo" #== "foo"
     , testCase "#&& - boolean and; #|| - boolean or" $ do
         let ptrue = pcon PTrue
             pfalse = pcon PFalse
@@ -183,13 +183,13 @@ plutarchTests =
         let d :: ScriptPurpose
             d = Minting dummyCurrency
             f :: Term s PScriptPurpose
-            f = pconstant @PScriptPurpose d
+            f = pconstant @_ @PScriptPurpose d
          in printTerm f @?= "(program 1.0.0 #d8799f58201111111111111111111111111111111111111111111111111111111111111111ff)"
     , testCase "decode ScriptPurpose" $
         let d :: ScriptPurpose
             d = Minting dummyCurrency
             d' :: Term s PScriptPurpose
-            d' = pconstant @PScriptPurpose d
+            d' = pconstant @_ @PScriptPurpose d
             f :: Term s POpaque
             f = pmatch d' $ \case
               PMinting c -> popaque c
@@ -211,8 +211,8 @@ plutarchTests =
         printTerm (phoistAcyclic (punsafeBuiltin PLC.FstPair)) @?= "(program 1.0.0 fstPair)"
     , testCase "throws: hoist error" $ throws $ phoistAcyclic perror
     , testCase "PData equality" $ do
-        expect $ let dat = pconstant @PData (PlutusTx.List [PlutusTx.Constr 1 [PlutusTx.I 0]]) in dat #== dat
-        expect $ pnot #$ pconstant @PData (PlutusTx.Constr 0 []) #== pconstant @PData (PlutusTx.I 42)
+        expect $ let dat = pconstant @_ @PData (PlutusTx.List [PlutusTx.Constr 1 [PlutusTx.I 0]]) in dat #== dat
+        expect $ pnot #$ pconstant @_ @PData (PlutusTx.Constr 0 []) #== pconstant @_ @PData (PlutusTx.I 42)
     , testCase "PAsData equality" $ do
         expect $ let dat = pdata @PInteger 42 in dat #== dat
         expect $ pnot #$ pdata (phexByteStr "12") #== pdata (phexByteStr "ab")
@@ -240,18 +240,18 @@ plutarchTests =
             plift' (pcon PTrue) @?= Right True
             plift' (pcon PFalse) @?= Right False
         , testCase "pconstant on primitive types" $ do
-            plift' (pconstant @PBool False) @?= Right False
-            plift' (pconstant @PBool True) @?= Right True
+            plift' (pconstant @_ @PBool False) @?= Right False
+            plift' (pconstant @_ @PBool True) @?= Right True
         , testCase "plift on list and pair" $ do
-            plift' (pconstant @(PBuiltinList PInteger) [1, 2, 3]) @?= Right [1, 2, 3]
-            plift' (pconstant @(PBuiltinPair PString PInteger) ("IOHK", 42)) @?= Right ("IOHK", 42)
+            plift' (pconstant @_ @(PBuiltinList PInteger) [1, 2, 3]) @?= Right [1, 2, 3]
+            plift' (pconstant @_ @(PBuiltinPair PString PInteger) ("IOHK", 42)) @?= Right ("IOHK", 42)
         , testCase "plift on nested containers" $ do
             -- List of pairs
             let v1 = [("IOHK", 42), ("Plutus", 31)]
-            plift' (pconstant @(PBuiltinList (PBuiltinPair PString PInteger)) v1) @?= Right v1
+            plift' (pconstant @_ @(PBuiltinList (PBuiltinPair PString PInteger)) v1) @?= Right v1
             -- List of pair of lists
             let v2 = [("IOHK", [1, 2, 3]), ("Plutus", [9, 8, 7])]
-            plift' (pconstant @(PBuiltinList (PBuiltinPair PString (PBuiltinList PInteger))) v2) @?= Right v2
+            plift' (pconstant @_ @(PBuiltinList (PBuiltinPair PString (PBuiltinList PInteger))) v2) @?= Right v2
         ]
     ]
 

--- a/examples/Main.hs
+++ b/examples/Main.hs
@@ -243,10 +243,10 @@ plutarchTests =
         , testCase "pconstant on primitive types" $ do
             plift' (pconstant @PBool False) @?= Right False
             plift' (pconstant @PBool True) @?= Right True
-        , testCase "plift on list and pair" $do 
+        , testCase "plift on list and pair" $ do
             plift' (pconstant @(PBuiltinList PInteger) [1, 2, 3]) @?= Right [1, 2, 3]
             plift' (pconstant @(PBuiltinPair PString PInteger) ("IOHK", 42)) @?= Right ("IOHK", 42)
-        , testCase "plift on nested containers" $do 
+        , testCase "plift on nested containers" $ do
             -- List of pairs
             let v1 = [("IOHK", 42), ("Plutus", 31)]
             plift' (pconstant @(PBuiltinList (PBuiltinPair PString PInteger)) v1) @?= Right v1

--- a/examples/Main.hs
+++ b/examples/Main.hs
@@ -10,13 +10,14 @@ import qualified Data.Aeson as Aeson
 import qualified Data.ByteString as BS
 import Data.Maybe (fromJust)
 import Data.Text (Text)
-import Plutarch (ClosedTerm, POpaque, compile, popaque, printScript, printTerm, punsafeBuiltin, punsafeCoerce, punsafeConstant)
+import Plutarch (ClosedTerm, POpaque, compile, popaque, printScript, printTerm, punsafeBuiltin, punsafeCoerce)
 import Plutarch.Bool (PBool (PFalse, PTrue), pif, pnot, (#&&), (#<), (#<=), (#==), (#||))
 import Plutarch.Builtin (PBuiltinList, PBuiltinPair, PData, pdata, pdataLiteral)
 import Plutarch.ByteString (pbyteStr, pconsBS, phexByteStr, pindexBS, plengthBS, psliceBS)
 import Plutarch.Either (PEither (PLeft, PRight))
 import Plutarch.Evaluate (evaluateScript)
 import Plutarch.Integer (PInteger)
+import Plutarch.Internal (punsafeConstant)
 import Plutarch.Lift
 import Plutarch.Prelude
 import Plutarch.ScriptContext (PScriptPurpose (PMinting))

--- a/examples/Main.hs
+++ b/examples/Main.hs
@@ -117,9 +117,9 @@ plutarchTests =
     , testCase "example2" $ (printTerm example2) @?= "(program 1.0.0 (\\i0 -> i1 (\\i0 -> addInteger i1 1) (\\i0 -> subtractInteger i1 1)))"
     , testCase "pfix" $ (printTerm pfix) @?= "(program 1.0.0 (\\i0 -> (\\i0 -> i2 (\\i0 -> i2 i2 i1)) (\\i0 -> i2 (\\i0 -> i2 i2 i1))))"
     , testCase "fib" $ (printTerm fib) @?= "(program 1.0.0 ((\\i0 -> (\\i0 -> (\\i0 -> i2 (\\i0 -> i2 i2 i1)) (\\i0 -> i2 (\\i0 -> i2 i2 i1))) (\\i0 -> \\i0 -> force (i3 (equalsInteger i1 0) (delay 0) (delay (force (i3 (equalsInteger i1 1) (delay 1) (delay (addInteger (i2 (subtractInteger i1 1)) (i2 (subtractInteger i1 2)))))))))) (force ifThenElse)))"
-    , testCase "fib 9 == 34" $ equal (fib # 9) (pconstant @_ @PInteger 34)
+    , testCase "fib 9 == 34" $ equal (fib # 9) (pconstant @PInteger 34)
     , testCase "uglyDouble" $ (printTerm uglyDouble) @?= "(program 1.0.0 (\\i0 -> addInteger i1 i1))"
-    , testCase "1 + 2 == 3" $ equal (pconstant @_ @PInteger $ 1 + 2) (pconstant @_ @PInteger 3)
+    , testCase "1 + 2 == 3" $ equal (pconstant @PInteger $ 1 + 2) (pconstant @PInteger 3)
     , testCase "fails: perror" $ fails perror
     , testCase "pnot" $ do
         (pnot #$ pcon PTrue) `equal` pcon PFalse
@@ -133,40 +133,40 @@ plutarchTests =
     , testCase "() <= () == True" $ do
         expect $ pcon PUnit #<= pcon PUnit
     , testCase "0x02af == 0x02af" $ expect $ phexByteStr "02af" #== phexByteStr "02af"
-    , testCase "\"foo\" == \"foo\"" $ expect $ "foo" #== pconstant @_ @PString "foo"
+    , testCase "\"foo\" == \"foo\"" $ expect $ "foo" #== pconstant @PString "foo"
     , testCase "PByteString :: mempty <> a == a <> mempty == a" $ do
         expect $ let a = phexByteStr "152a" in (mempty <> a) #== a
         expect $ let a = phexByteStr "4141" in (a <> mempty) #== a
     , testCase "PString :: mempty <> a == a <> mempty == a" $ do
-        expect $ let a = pconstant @_ @PString "foo" in (mempty <> a) #== a
-        expect $ let a = pconstant @_ @PString "bar" in (a <> mempty) #== a
+        expect $ let a = pconstant @PString "foo" in (mempty <> a) #== a
+        expect $ let a = pconstant @PString "bar" in (a <> mempty) #== a
     , testCase "PByteString :: 0x12 <> 0x34 == 0x1234" $
         expect $
           (phexByteStr "12" <> phexByteStr "34") #== phexByteStr "1234"
     , testCase "PString :: \"ab\" <> \"cd\" == \"abcd\"" $
         expect $
-          ("ab" <> "cd") #== (pconstant @_ @PString "abcd")
+          ("ab" <> "cd") #== (pconstant @PString "abcd")
     , testCase "PByteString mempty" $ expect $ mempty #== phexByteStr ""
     , testCase "pconsByteStr" $
         let xs = "5B1F"; b = "41"
          in (pconsBS # fromInteger (readByte b) # phexByteStr xs) `equal` phexByteStr (b <> xs)
     , testCase "plengthByteStr" $ do
-        (plengthBS # phexByteStr "012f") `equal` pconstant @_ @PInteger 2
+        (plengthBS # phexByteStr "012f") `equal` pconstant @PInteger 2
         expect $ (plengthBS # phexByteStr "012f") #== 2
         let xs = phexByteStr "48fCd1"
         (plengthBS #$ pconsBS # 91 # xs)
           `equal` (1 + plengthBS # xs)
     , testCase "pindexByteStr" $
-        (pindexBS # phexByteStr "4102af" # 1) `equal` pconstant @_ @PInteger 0x02
+        (pindexBS # phexByteStr "4102af" # 1) `equal` pconstant @PInteger 0x02
     , testCase "psliceByteStr" $
         (psliceBS # 1 # 3 # phexByteStr "4102afde5b2a") `equal` phexByteStr "02afde"
     , testCase "pconstant - phexByteStr relation" $ do
         let a = ["42", "ab", "df", "c9"]
-        pconstant @_ @PByteString (BS.pack $ map readByte a) `equal` phexByteStr (concat a)
-    , testCase "PString mempty" $ expect $ mempty #== pconstant @_ @PString ""
+        pconstant @PByteString (BS.pack $ map readByte a) `equal` phexByteStr (concat a)
+    , testCase "PString mempty" $ expect $ mempty #== pconstant @PString ""
     , testCase "pconstant \"abc\" == \"abc\"" $ do
-        pconstant @_ @PString "abc" `equal` pconstant @_ @PString "abc"
-        expect $ pconstant @_ @PString "foo" #== "foo"
+        pconstant @PString "abc" `equal` pconstant @PString "abc"
+        expect $ pconstant @PString "foo" #== "foo"
     , testCase "#&& - boolean and; #|| - boolean or" $ do
         let ptrue = pcon PTrue
             pfalse = pcon PFalse
@@ -184,13 +184,13 @@ plutarchTests =
         let d :: ScriptPurpose
             d = Minting dummyCurrency
             f :: Term s PScriptPurpose
-            f = pconstant @_ @PScriptPurpose d
+            f = pconstant @PScriptPurpose d
          in printTerm f @?= "(program 1.0.0 #d8799f58201111111111111111111111111111111111111111111111111111111111111111ff)"
     , testCase "decode ScriptPurpose" $
         let d :: ScriptPurpose
             d = Minting dummyCurrency
             d' :: Term s PScriptPurpose
-            d' = pconstant @_ @PScriptPurpose d
+            d' = pconstant @PScriptPurpose d
             f :: Term s POpaque
             f = pmatch d' $ \case
               PMinting c -> popaque c
@@ -212,8 +212,8 @@ plutarchTests =
         printTerm (phoistAcyclic (punsafeBuiltin PLC.FstPair)) @?= "(program 1.0.0 fstPair)"
     , testCase "throws: hoist error" $ throws $ phoistAcyclic perror
     , testCase "PData equality" $ do
-        expect $ let dat = pconstant @_ @PData (PlutusTx.List [PlutusTx.Constr 1 [PlutusTx.I 0]]) in dat #== dat
-        expect $ pnot #$ pconstant @_ @PData (PlutusTx.Constr 0 []) #== pconstant @_ @PData (PlutusTx.I 42)
+        expect $ let dat = pconstant @PData (PlutusTx.List [PlutusTx.Constr 1 [PlutusTx.I 0]]) in dat #== dat
+        expect $ pnot #$ pconstant @PData (PlutusTx.Constr 0 []) #== pconstant @PData (PlutusTx.I 42)
     , testCase "PAsData equality" $ do
         expect $ let dat = pdata @PInteger 42 in dat #== dat
         expect $ pnot #$ pdata (phexByteStr "12") #== pdata (phexByteStr "ab")
@@ -242,18 +242,18 @@ plutarchTests =
             plift' (pcon PTrue) @?= Right True
             plift' (pcon PFalse) @?= Right False
         , testCase "pconstant on primitive types" $ do
-            plift' (pconstant @_ @PBool False) @?= Right False
-            plift' (pconstant @_ @PBool True) @?= Right True
+            plift' (pconstant @PBool False) @?= Right False
+            plift' (pconstant @PBool True) @?= Right True
         , testCase "plift on list and pair" $ do
-            plift' (pconstant @_ @(PBuiltinList PInteger) [1, 2, 3]) @?= Right [1, 2, 3]
-            plift' (pconstant @_ @(PBuiltinPair PString PInteger) ("IOHK", 42)) @?= Right ("IOHK", 42)
+            plift' (pconstant @(PBuiltinList PInteger) [1, 2, 3]) @?= Right [1, 2, 3]
+            plift' (pconstant @(PBuiltinPair PString PInteger) ("IOHK", 42)) @?= Right ("IOHK", 42)
         , testCase "plift on nested containers" $ do
             -- List of pairs
             let v1 = [("IOHK", 42), ("Plutus", 31)]
-            plift' (pconstant @_ @(PBuiltinList (PBuiltinPair PString PInteger)) v1) @?= Right v1
+            plift' (pconstant @(PBuiltinList (PBuiltinPair PString PInteger)) v1) @?= Right v1
             -- List of pair of lists
             let v2 = [("IOHK", [1, 2, 3]), ("Plutus", [9, 8, 7])]
-            plift' (pconstant @_ @(PBuiltinList (PBuiltinPair PString (PBuiltinList PInteger))) v2) @?= Right v2
+            plift' (pconstant @(PBuiltinList (PBuiltinPair PString (PBuiltinList PInteger))) v2) @?= Right v2
         ]
     ]
 

--- a/examples/Main.hs
+++ b/examples/Main.hs
@@ -125,6 +125,15 @@ plutarchTests =
     , testCase "pnot" $ do
         (pnot #$ pcon PTrue) `equal` pcon PFalse
         (pnot #$ pcon PFalse) `equal` pcon PTrue
+    , testGroup
+        "Lift"
+        [ testCase "plift" $ do
+            plift' (pcon PTrue) @?= Right True
+            plift' (pcon PFalse) @?= Right False
+        , testCase "pconstant" $ do
+            plift' (pconstant @PBool False) @?= Right False
+            plift' (pconstant @PBool True) @?= Right True
+        ]
     , testCase "() == ()" $ do
         expect $ pmatch (pcon PUnit) (\case PUnit -> pcon PTrue)
         expect $ pcon PUnit #== pcon PUnit

--- a/examples/Main.hs
+++ b/examples/Main.hs
@@ -9,7 +9,7 @@ import Control.Exception (SomeException, try)
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString as BS
 import Data.Maybe (fromJust)
-import Plutarch (ClosedTerm, POpaque, compile, pconstant, plift', popaque, printScript, printTerm, punsafeBuiltin, punsafeCoerce)
+import Plutarch (ClosedTerm, POpaque, compile, pconstant, plift', popaque, printScript, printTerm, punsafeBuiltin)
 import Plutarch.Bool (PBool (PFalse, PTrue), pif, pnot, (#&&), (#<), (#<=), (#==), (#||))
 import Plutarch.Builtin (PBuiltinList, PBuiltinPair, PData, pdata)
 import Plutarch.ByteString (PByteString, pconsBS, phexByteStr, pindexBS, plengthBS, psliceBS)
@@ -26,7 +26,6 @@ import Plutus.V1.Ledger.Value (CurrencySymbol (CurrencySymbol))
 import Plutus.V2.Ledger.Contexts (ScriptPurpose (Minting))
 import qualified PlutusCore as PLC
 import qualified PlutusTx
-import PlutusTx.IsData.Class (toData)
 
 main :: IO ()
 main = defaultMain tests
@@ -183,14 +182,14 @@ plutarchTests =
     , testCase "ScriptPurpose literal" $
         let d :: ScriptPurpose
             d = Minting dummyCurrency
-            f :: Term s PData
-            f = pconstant $ toData d
+            f :: Term s PScriptPurpose
+            f = pconstant @PScriptPurpose d
          in printTerm f @?= "(program 1.0.0 #d8799f58201111111111111111111111111111111111111111111111111111111111111111ff)"
     , testCase "decode ScriptPurpose" $
         let d :: ScriptPurpose
             d = Minting dummyCurrency
             d' :: Term s PScriptPurpose
-            d' = punsafeCoerce $ pconstant @PData $ toData d
+            d' = pconstant @PScriptPurpose d
             f :: Term s POpaque
             f = pmatch d' $ \case
               PMinting c -> popaque c

--- a/plutarch.cabal
+++ b/plutarch.cabal
@@ -88,6 +88,7 @@ library
     Plutarch.Maybe
     Plutarch.Unit
     Plutarch.Crypto
+    Plutarch.Lift
   build-depends:
     , base
     , plutus-core
@@ -113,6 +114,7 @@ test-suite examples
     , plutarch
     , tasty
     , tasty-hunit
+    , text
     , plutus-ledger-api
     , plutus-core
     , aeson

--- a/plutarch.cabal
+++ b/plutarch.cabal
@@ -42,7 +42,6 @@ common c
     GeneralisedNewtypeDeriving
     HexFloatLiterals
     ImplicitPrelude
-    ImportQualifiedPost
     InstanceSigs
     KindSignatures
     MonomorphismRestriction

--- a/plutarch.cabal
+++ b/plutarch.cabal
@@ -34,6 +34,7 @@ common c
     DeriveGeneric
     DeriveLift
     DeriveTraversable
+    DerivingVia
     DoAndIfThenElse
     EmptyCase
     EmptyDataDecls


### PR DESCRIPTION
@L-as Is this a right approach for resolving #53 ?

- [x] Initial implementation
- [x] Clarify `plift` semantics
- [x] Use `plift` in examples
- [x] Replace hand-written functions with plift/pconstant
- [x] Avoid having to (unsafely) specify Plutus type, as in: `pconstant @Integer @PInteger 3`
- [x] Fix confusing naming
- [x] Reevaluate PList in context of DerivingVia (see comment)

Resolves #53 
Resolves #61 
Closes #51 