### PR TITLE
Some scattered general cleanup

### DIFF
--- a/Plutarch/Builtin.hs
+++ b/Plutarch/Builtin.hs
@@ -98,10 +98,9 @@ instance InDefaultUni a => PlutusType (PBuiltinList a) where
 
 instance PListLike PBuiltinList where
   type PElemConstraint PBuiltinList a = InDefaultUni a
-  pelimList match_cons match_nil =
-    plam $ \ls -> pmatch ls $ \case
-      PCons x xs -> match_cons # x # xs
-      PNil -> match_nil
+  pelimList match_cons match_nil ls = pmatch ls $ \case
+    PCons x xs -> match_cons x xs
+    PNil -> match_nil
   pcons = plam $ \x xs -> pcon (PCons x xs)
   pnil = pcon PNil
   phead = pheadBuiltin

--- a/Plutarch/Builtin.hs
+++ b/Plutarch/Builtin.hs
@@ -83,7 +83,7 @@ pconsBuiltin = phoistAcyclic $ pforce $ punsafeBuiltin PLC.MkCons
 instance PLC.DefaultUni `PLC.Contains` PHaskellType a => PlutusType (PBuiltinList a) where
   type PInner (PBuiltinList a) b = PBuiltinList a
   pcon' :: forall s. PBuiltinList a s -> forall b. Term s (PInner (PBuiltinList a) b)
-  pcon' (PCons x xs) = pconsBuiltin # x # (pto xs)
+  pcon' (PCons x xs) = pconsBuiltin # x # pto xs
   pcon' PNil = pconstant @(PBuiltinList a) []
   pmatch' xs f =
     pforce $

--- a/Plutarch/Builtin.hs
+++ b/Plutarch/Builtin.hs
@@ -9,7 +9,6 @@ module Plutarch.Builtin (
   pasMap,
   pasList,
   pasInt,
-  pnullBuiltin,
   pasByteStr,
   PBuiltinPair,
   PBuiltinList (..),
@@ -106,6 +105,7 @@ instance PListLike PBuiltinList where
   pnil = pcon PNil
   phead = pheadBuiltin
   ptail = ptailBuiltin
+  pnull = pnullBuiltin
 
 instance (PElemConstraint PBuiltinList a, PEq a) => PEq (PBuiltinList a) where
   (#==) xs ys = plistEquals # xs # ys

--- a/Plutarch/Builtin.hs
+++ b/Plutarch/Builtin.hs
@@ -16,6 +16,7 @@ module Plutarch.Builtin (
   pdataLiteral,
   PIsData (..),
   PAsData,
+  pforgetData,
   ppairDataBuiltin,
 ) where
 

--- a/Plutarch/Builtin.hs
+++ b/Plutarch/Builtin.hs
@@ -100,7 +100,7 @@ instance PListLike PBuiltinList where
   pelimList match_cons match_nil =
     plam $ \ls -> pmatch ls $ \case
       PCons x xs -> match_cons # x # xs
-      PNil -> pforce match_nil
+      PNil -> match_nil
   pcons = plam $ \x xs -> pcon (PCons x xs)
   pnil = pcon PNil
   phead = pheadBuiltin

--- a/Plutarch/Builtin.hs
+++ b/Plutarch/Builtin.hs
@@ -70,13 +70,13 @@ ptailBuiltin :: Term s (PBuiltinList a :--> PBuiltinList a)
 ptailBuiltin = phoistAcyclic $ pforce $ punsafeBuiltin PLC.TailList
 
 pchooseListBuiltin :: Term s (PBuiltinList a :--> b :--> b :--> b)
-pchooseListBuiltin = pforce $ pforce $ punsafeBuiltin PLC.ChooseList
+pchooseListBuiltin = phoistAcyclic $ pforce $ pforce $ punsafeBuiltin PLC.ChooseList
 
 pnullBuiltin :: Term s (PBuiltinList a :--> PBool)
 pnullBuiltin = phoistAcyclic $ pforce $ punsafeBuiltin PLC.NullList
 
 pconsBuiltin :: Term s (a :--> PBuiltinList a :--> PBuiltinList a)
-pconsBuiltin = pforce $ punsafeBuiltin PLC.MkCons
+pconsBuiltin = phoistAcyclic $ pforce $ punsafeBuiltin PLC.MkCons
 
 --------------------------------------------------------------------------------
 

--- a/Plutarch/DataRepr.hs
+++ b/Plutarch/DataRepr.hs
@@ -95,7 +95,7 @@ pmatchDataRepr d handlers =
 
     applyHandlers :: Term s (PBuiltinList PData) -> DataReprHandlers out defs s -> [Term s out]
     applyHandlers _ DRHNil = []
-    applyHandlers args (DRHCons handler rest) = (handler $ punsafeCoerce args) : applyHandlers args rest
+    applyHandlers args (DRHCons handler rest) = handler (punsafeCoerce args) : applyHandlers args rest
 
     go ::
       (Dig, Term s out) ->

--- a/Plutarch/Either.hs
+++ b/Plutarch/Either.hs
@@ -9,4 +9,4 @@ instance PlutusType (PEither a b) where
   type PInner (PEither a b) c = (a :--> c) :--> (b :--> c) :--> c
   pcon' (PLeft x) = plam $ \f (_ :: Term _ _) -> f # x
   pcon' (PRight y) = plam $ \_ g -> g # y
-  pmatch' p f = p # (plam $ \x -> f . PLeft $ x) # (plam $ \y -> f . PRight $ y)
+  pmatch' p f = p # plam (f . PLeft) # plam (f . PRight)

--- a/Plutarch/List.hs
+++ b/Plutarch/List.hs
@@ -10,7 +10,6 @@ module Plutarch.List (
   -- * Query
   pelem,
   plength,
-  pnull,
 
   -- * Construction
   psingleton,
@@ -79,6 +78,10 @@ class PListLike (list :: (k -> Type) -> k -> Type) where
   ptail :: PIsListLike list a => Term s (list a :--> list a)
   ptail = pelimList (plam $ \_x xs -> xs) (pdelay perror)
 
+  -- | / O(1) /. Check if a list is empty
+  pnull :: PIsListLike list a => Term s (list a :--> PBool)
+  pnull = phoistAcyclic $ pelimList (plam $ \_ _ -> pconstant False) $ pdelay (pconstant True)
+
 class EmptyConstraint x
 instance EmptyConstraint x
 
@@ -139,10 +142,6 @@ plength =
           # ls
     )
     $ \go -> plam $ \xs -> go # xs # 0
-
--- | / O(1) /. Check if a list is empty
-pnull :: PIsListLike list a => Term s (list a :--> PBool)
-pnull = pelimList (plam $ \_ _ -> pcon PFalse) (pdelay $ pcon PTrue)
 
 --------------------------------------------------------------------------------
 

--- a/Plutarch/List.hs
+++ b/Plutarch/List.hs
@@ -82,10 +82,8 @@ class PListLike (list :: (k -> Type) -> k -> Type) where
   pnull :: PIsListLike list a => Term s (list a :--> PBool)
   pnull = phoistAcyclic $ pelimList (plam $ \_ _ -> pconstant False) $ pconstant True
 
-type EmptyConstraint = 'True ~ 'True
-
 instance PListLike PList where
-  type PElemConstraint PList _ = EmptyConstraint
+  type PElemConstraint PList _ = ()
   pelimList match_cons match_nil =
     plam $ \ls -> pmatch ls $ \case
       PSCons x xs -> match_cons # x # xs

--- a/Plutarch/List.hs
+++ b/Plutarch/List.hs
@@ -59,7 +59,7 @@ instance PEq a => PEq (PList a) where
 
 -- | Plutarch types that behave like lists.
 class PListLike (list :: (k -> Type) -> k -> Type) where
-  type PElemConstraint list :: (k -> Type) -> Constraint
+  type PElemConstraint list (a :: k -> Type) :: Constraint
 
   -- | Canonical eliminator for list-likes.
   pelimList :: PElemConstraint list a => Term s (a :--> list a :--> r) -> Term s r -> Term s (list a :--> r)
@@ -82,11 +82,10 @@ class PListLike (list :: (k -> Type) -> k -> Type) where
   pnull :: PIsListLike list a => Term s (list a :--> PBool)
   pnull = phoistAcyclic $ pelimList (plam $ \_ _ -> pconstant False) $ pconstant True
 
-class EmptyConstraint x
-instance EmptyConstraint x
+type EmptyConstraint = 'True ~ 'True
 
 instance PListLike PList where
-  type PElemConstraint PList = EmptyConstraint
+  type PElemConstraint PList _ = EmptyConstraint
   pelimList match_cons match_nil =
     plam $ \ls -> pmatch ls $ \case
       PSCons x xs -> match_cons # x # xs

--- a/Plutarch/Maybe.hs
+++ b/Plutarch/Maybe.hs
@@ -14,4 +14,4 @@ instance PlutusType (PMaybe a) where
   pcon' :: forall s. PMaybe a s -> forall b. Term s (PInner (PMaybe a) b)
   pcon' (PJust x) = plam $ \f (_ :: Term _ _) -> f # x
   pcon' PNothing = plam $ \_ g -> pforce g
-  pmatch' x f = x # (plam $ \inner -> f (PJust inner)) # (pdelay $ f PNothing)
+  pmatch' x f = x # plam (f . PJust) # pdelay (f PNothing)


### PR DESCRIPTION
* Hoist the `ChooseList` and `MkCons` synonyms
* Export `pforgetData` - useful to get a `PData` out of a `PAsData a` for whatever `a`. This should be a safe operation regardless.
* Make `pnull` a `PListLike` class method so the builtin list instance can bind it to `pnullBuiltin`
* Remove redundant delay/force in `pelimList` - should be handled by underlying `pmatch` AFAIK
* General formatting cleanup + hoist a bunch of list utilities
* Make `IsDefaultUni` a type alias and export it - it'll be more convenient for users to write than `PLC.KnownType...` etc.
* Make `pelimList` take haskell level function arguments. `pelimList` itself is now also a haskell level function entirely.