### PR TITLE
Add GHC flags for explicit foralls/ kinds

### DIFF
--- a/plutarch.cabal
+++ b/plutarch.cabal
@@ -63,7 +63,7 @@ common c
     ScopedTypeVariables
     StandaloneDeriving
     StandaloneKindSignatures
-    StarIsType
+    NoStarIsType
     TraditionalRecordSyntax
     TupleSections
     TypeApplications

--- a/plutarch.cabal
+++ b/plutarch.cabal
@@ -72,7 +72,8 @@ common c
   ghc-options:
     -Wall -Wcompat -Wincomplete-uni-patterns -Wno-partial-type-signatures
     -Wmissing-export-lists -Werror -Wincomplete-record-updates
-    -Wmissing-deriving-strategies -Wno-name-shadowing
+    -Wmissing-deriving-strategies -Wno-name-shadowing -Wunused-foralls
+    -fprint-explicit-foralls -fprint-explicit-kinds
 
 library
   import: c


### PR DESCRIPTION
As long as we are going to be using the `k`, I thought this would be useful to have by default:

```haskell
> :k Term
Term :: forall k. k -> (k -> *) -> *
```

```haskell
> :k PBool
PBool :: forall {k}. k -> *
```