### PR TITLE
`s :: S`

### DIFF
--- a/Plutarch.hs
+++ b/Plutarch.hs
@@ -22,6 +22,8 @@ module Plutarch (
   PI.punsafeConstant,
   PI.Term,
   PI.TermCont (..),
+  PI.S,
+  PI.PType,
   PlutusType (..),
   printTerm,
   printScript,
@@ -37,11 +39,9 @@ module Plutarch (
   popaque,
   punsafeFromOpaque,
   plam,
-  -- $plam
 ) where
 
-import Data.Kind (Type)
-import Plutarch.Internal (ClosedTerm, Term, compile, papp, phoistAcyclic, plam', punsafeCoerce, (:-->))
+import Plutarch.Internal (ClosedTerm, PType, Term, compile, papp, phoistAcyclic, plam', punsafeCoerce, (:-->))
 import qualified Plutarch.Internal as PI
 import Plutus.V1.Ledger.Scripts (Script (Script))
 import PlutusCore.Pretty (prettyPlcReadableDebug)
@@ -135,7 +135,7 @@ pinl v f = f v
 
   A simple example, encoding a Sum type as an Enum via PInteger:
 
-  > data AB (s :: k) = A | B
+  > data AB (s :: S) = A | B
   >
   > instance PlutusType AB where
   >   type PInner AB _ = PInteger
@@ -157,10 +157,10 @@ pinl v f = f v
 
   Further examples can be found in examples/PlutusType.hs
 -}
-class (PCon a, PMatch a) => PlutusType (a :: k -> Type) where
+class (PCon a, PMatch a) => PlutusType (a :: PType) where
   -- `b' :: k'` causes GHC to fail type checking at various places
   -- due to not being able to expand the type family.
-  type PInner a (b' :: k -> Type) :: k -> Type
+  type PInner a (b' :: PType) :: PType
   pcon' :: forall s. a s -> forall b. Term s (PInner a b)
   pmatch' :: forall s c. (forall b. Term s (PInner a b)) -> (a s -> Term s c) -> Term s c
 

--- a/Plutarch.hs
+++ b/Plutarch.hs
@@ -22,9 +22,6 @@ module Plutarch (
   PI.punsafeConstant,
   PI.Term,
   PI.TermCont (..),
-  PL.plift,
-  PL.pconstant,
-  PL.plift',
   PlutusType (..),
   printTerm,
   printScript,
@@ -46,7 +43,6 @@ module Plutarch (
 import Data.Kind (Type)
 import Plutarch.Internal (ClosedTerm, Term, compile, papp, phoistAcyclic, plam', punsafeCoerce, (:-->))
 import qualified Plutarch.Internal as PI
-import qualified Plutarch.Lift as PL
 import Plutus.V1.Ledger.Scripts (Script (Script))
 import PlutusCore.Pretty (prettyPlcReadableDebug)
 

--- a/Plutarch/Api/V1.hs
+++ b/Plutarch/Api/V1.hs
@@ -86,7 +86,7 @@ type PTuple = PDataList
 
 ---------- V1 Specific types, Incompatible with V2
 
-newtype PTxInfo (s :: k)
+newtype PTxInfo (s :: S)
   = PTxInfo
       ( Term
           s
@@ -126,7 +126,7 @@ instance PIsDataRepr PTxInfo where
   pmatchRepr dat f =
     (pmatchDataRepr dat) ((DRHCons (f . PTxInfo)) $ DRHNil)
 
-newtype PScriptContext (s :: k)
+newtype PScriptContext (s :: S)
   = PScriptContext (Term s (PDataList '[PTxInfo, PScriptPurpose]))
   deriving
     (PMatch, PIsData, PUnsafeLiftDecl Plutus.ScriptContext)
@@ -144,7 +144,7 @@ instance PIsDataRepr PScriptContext where
 
 -- General types, used by V1 and V2
 
-data PScriptPurpose (s :: k)
+data PScriptPurpose (s :: S)
   = PMinting (Term s (PDataList '[PCurrencySymbol]))
   | PSpending (Term s (PDataList '[PTxOutRef]))
   | PRewarding (Term s (PDataList '[PStakingCredential]))
@@ -173,60 +173,60 @@ instance PIsDataRepr PScriptPurpose where
 
 ---------- Scripts
 
-newtype PDatum (s :: k) = PDatum (Term s PData)
+newtype PDatum (s :: S) = PDatum (Term s PData)
   deriving (PIsData, PEq) via PData
 
-newtype PRedeemer (s :: k) = PRedeemer (Term s PData)
+newtype PRedeemer (s :: S) = PRedeemer (Term s PData)
   deriving (PIsData, PEq) via PData
 
-newtype PDatumHash (s :: k)
+newtype PDatumHash (s :: S)
   = PDatumHash (Term s PByteString)
   deriving (PEq, POrd, PIsData) via PByteString
 
-newtype PStakeValidatorHash (s :: k)
+newtype PStakeValidatorHash (s :: S)
   = PStakeValidatorHash (Term s PByteString)
   deriving (PEq, POrd, PIsData) via PByteString
 
-newtype PRedeemerHash (s :: k)
+newtype PRedeemerHash (s :: S)
   = PRedeemerHash (Term s PByteString)
   deriving (PEq, POrd, PIsData) via PByteString
 
-newtype PValidatorHash (s :: k)
+newtype PValidatorHash (s :: S)
   = PValidatorHash (Term s PByteString)
   deriving (PEq, POrd, PIsData) via PByteString
 
 ---------- Value
 
-newtype PTokenName (s :: k)
+newtype PTokenName (s :: S)
   = PTokenName (Term s PByteString)
   deriving (PEq, POrd, PIsData) via (PByteString)
   deriving newtype (Semigroup, Monoid)
 
-newtype PValue (s :: k)
+newtype PValue (s :: S)
   = PValue (Term s (PMap PCurrencySymbol (PMap PTokenName PInteger)))
   deriving (PIsData) via (PMap PCurrencySymbol (PMap PTokenName PInteger))
 
-newtype PCurrencySymbol (s :: k)
+newtype PCurrencySymbol (s :: S)
   = PCurrencySymbol (Term s PByteString)
   deriving (PEq, POrd, PIsData) via PByteString
 
 ---------- Crypto
 
-newtype PPubKeyHash (s :: k)
+newtype PPubKeyHash (s :: S)
   = PPubKeyHash (Term s PByteString)
   deriving (PEq, POrd, PIsData) via PByteString
 
-newtype PPubKey (s :: k)
+newtype PPubKey (s :: S)
   = PPubKey (Term s PByteString)
   deriving (PEq, POrd, PIsData) via PByteString
 
-newtype PSignature (s :: k)
+newtype PSignature (s :: S)
   = PSignature (Term s PByteString)
   deriving (PEq, POrd, PIsData) via PByteString
 
 ---------- Time
 
-newtype PPOSIXTime (s :: k)
+newtype PPOSIXTime (s :: S)
   = PPOSIXTime (Term s PInteger)
   deriving (POrd, PEq, PIntegral, PIsData) via (PInteger)
   deriving newtype (Num)
@@ -237,7 +237,7 @@ type PPOSIXTimeRange = PInterval PPOSIXTime
 
 type PClosure = PBool
 
-newtype PInterval a (s :: k)
+newtype PInterval a (s :: S)
   = PInterval
       ( Term
           s
@@ -267,7 +267,7 @@ instance PIsDataRepr (PInterval a) where
     pmatchDataRepr dat $
       DRHCons (f . PInterval) DRHNil
 
-newtype PLowerBound a (s :: k)
+newtype PLowerBound a (s :: S)
   = PLowerBound (Term s (PDataList '[PExtended a, PClosure]))
   deriving
     ( PMatch
@@ -290,7 +290,7 @@ instance PIsDataRepr (PLowerBound a) where
     pmatchDataRepr dat $
       DRHCons (f . PLowerBound) DRHNil
 
-newtype PUpperBound a (s :: k)
+newtype PUpperBound a (s :: S)
   = PUpperBound (Term s (PDataList '[PExtended a, PClosure]))
   deriving
     ( PMatch
@@ -312,7 +312,7 @@ instance PIsDataRepr (PUpperBound a) where
     pmatchDataRepr dat $
       DRHCons (f . PUpperBound) DRHNil
 
-data PExtended a (s :: k)
+data PExtended a (s :: S)
   = PNegInf (Term s (PDataList '[]))
   | PFinite (Term s (PDataList '[a]))
   | PPosInf (Term s (PDataList '[]))
@@ -335,7 +335,7 @@ instance PIsDataRepr (PExtended a) where
 
 ---------- Tx/Address
 
-data PCredential (s :: k)
+data PCredential (s :: S)
   = PPubKeyCredential (Term s (PDataList '[PPubKeyHash]))
   | PScriptCredential (Term s (PDataList '[PValidatorHash]))
   deriving
@@ -356,7 +356,7 @@ instance PIsDataRepr PCredential where
           (f . PScriptCredential)
           DRHNil
 
-data PStakingCredential (s :: k)
+data PStakingCredential (s :: S)
   = PStakingHash (Term s (PDataList '[PCredential]))
   | PStakingPtr (Term s (PDataList '[PInteger, PInteger, PInteger]))
   deriving
@@ -377,7 +377,7 @@ instance PIsDataRepr PStakingCredential where
       DRHCons (f . PStakingHash) $
         DRHCons (f . PStakingPtr) DRHNil
 
-newtype PAddress (s :: k)
+newtype PAddress (s :: S)
   = PAddress
       ( Term
           s
@@ -405,7 +405,7 @@ instance PIsDataRepr PAddress where
 
 ---------- Tx
 
-newtype PTxId (s :: k)
+newtype PTxId (s :: S)
   = PTxId (Term s (PDataList '[PByteString]))
   deriving
     (PMatch, PIsData, PUnsafeLiftDecl Plutus.TxId)
@@ -418,7 +418,7 @@ instance PIsDataRepr PTxId where
     pmatchDataRepr dat $
       DRHCons (f . PTxId) DRHNil
 
-newtype PTxOutRef (s :: k)
+newtype PTxOutRef (s :: S)
   = PTxOutRef (Term s (PDataList '[PTxId, PInteger]))
   deriving
     (PMatch, PIsData, PUnsafeLiftDecl Plutus.TxOutRef)
@@ -431,7 +431,7 @@ instance PIsDataRepr PTxOutRef where
     pmatchDataRepr dat $
       DRHCons (f . PTxOutRef) DRHNil
 
-newtype PTxInInfo (s :: k)
+newtype PTxInInfo (s :: S)
   = PTxInInfo (Term s (PDataList '[PTxOutRef, PTxOut]))
   deriving
     (PMatch, PIsData, PUnsafeLiftDecl Plutus.TxInfo)
@@ -444,7 +444,7 @@ instance PIsDataRepr PTxInInfo where
     pmatchDataRepr dat $
       DRHCons (f . PTxInInfo) DRHNil
 
-newtype PTxOut (s :: k)
+newtype PTxOut (s :: S)
   = PTxOut
       ( Term
           s
@@ -472,7 +472,7 @@ instance PIsDataRepr PTxOut where
     pmatchDataRepr dat $
       DRHCons (f . PTxOut) DRHNil
 
-data PDCert (s :: k)
+data PDCert (s :: S)
   = PDCertDelegRegKey (Term s (PDataList '[PStakingCredential]))
   | PDCertDelegDeRegKey (Term s (PDataList '[PStakingCredential]))
   | PDCertDelegDelegate (Term s (PDataList '[PStakingCredential, PPubKeyHash]))
@@ -508,13 +508,13 @@ instance PIsDataRepr PDCert where
 
 ---------- AssocMap
 
-newtype PMap (a :: k -> Type) (b :: k -> Type) (s :: k)
+newtype PMap (a :: PType) (b :: PType) (s :: S)
   = PMap (Term s (PBuiltinMap a b))
   deriving (PIsData) via (PBuiltinMap a b)
 
 ---------- Others
 
-data PMaybe a (s :: k)
+data PMaybe a (s :: S)
   = PNothing (Term s (PDataList '[]))
   | PJust (Term s (PDataList '[a]))
   deriving
@@ -531,7 +531,7 @@ instance PIsDataRepr (PMaybe a) where
       DRHCons (f . PNothing) $
         DRHCons (f . PJust) DRHNil
 
-data PEither a b (s :: k)
+data PEither a b (s :: S)
   = PLeft (Term s (PDataList '[a]))
   | PRight (Term s (PDataList '[b]))
   deriving

--- a/Plutarch/Builtin.hs
+++ b/Plutarch/Builtin.hs
@@ -33,16 +33,16 @@ import qualified PlutusCore as PLC
 import PlutusTx (Data)
 
 -- | Plutus 'BuiltinPair'
-data PBuiltinPair (a :: k -> Type) (b :: k -> Type) (s :: k)
+data PBuiltinPair (a :: PType) (b :: PType) (s :: S)
 
 -- FIXME: figure out good way of deriving this
 instance (PUnsafeLiftDecl ah a, PUnsafeLiftDecl bh b) => PUnsafeLiftDecl (ah, bh) (PBuiltinPair a b) where
   type PLiftedRepr (PBuiltinPair a b) = (PLiftedRepr a, PLiftedRepr b)
   type PLifted (PBuiltinPair a b) = (PLifted a, PLifted b)
-  pliftToRepr (x, y) = (pliftToRepr @_ @_ @a x, pliftToRepr @_ @_ @b y)
+  pliftToRepr (x, y) = (pliftToRepr @_ @a x, pliftToRepr @_ @b y)
   pliftFromRepr (x, y) = do
-    x' <- pliftFromRepr @_ @_ @a x
-    y' <- pliftFromRepr @_ @_ @b y
+    x' <- pliftFromRepr @_ @a x
+    y' <- pliftFromRepr @_ @b y
     Just (x', y')
 
 pfstBuiltin :: Term s (PBuiltinPair a b :--> a)
@@ -59,7 +59,7 @@ ppairDataBuiltin :: Term s (PAsData a :--> PAsData b :--> PBuiltinPair (PAsData 
 ppairDataBuiltin = punsafeBuiltin PLC.MkPairData
 
 -- | Plutus 'BuiltinList'
-data PBuiltinList (a :: k -> Type) (s :: k)
+data PBuiltinList (a :: PType) (s :: S)
   = PCons (Term s a) (Term s (PBuiltinList a))
   | PNil
 
@@ -81,8 +81,8 @@ pconsBuiltin = phoistAcyclic $ pforce $ punsafeBuiltin PLC.MkCons
 instance PUnsafeLiftDecl ah a => PUnsafeLiftDecl [ah] (PBuiltinList a) where
   type PLifted (PBuiltinList a) = [PLifted a]
   type PLiftedRepr (PBuiltinList a) = [PLiftedRepr a]
-  pliftToRepr x = pliftToRepr @_ @_ @a <$> x
-  pliftFromRepr x = traverse (pliftFromRepr @_ @_ @a) x
+  pliftToRepr x = pliftToRepr @_ @a <$> x
+  pliftFromRepr x = traverse (pliftFromRepr @_ @a) x
 
 instance PLift a => PlutusType (PBuiltinList a) where
   type PInner (PBuiltinList a) _ = PBuiltinList a
@@ -150,9 +150,9 @@ pasByteStr = punsafeBuiltin PLC.UnBData
 pdataLiteral :: Data -> Term s PData
 pdataLiteral = pconstant
 
-data PAsData (a :: k -> Type) (s :: k)
+data PAsData (a :: PType) (s :: S)
 
-data PAsDataLifted (a :: k -> Type)
+data PAsDataLifted (a :: PType)
 
 instance PUnsafeLiftDecl (PAsDataLifted a) (PAsData a) where
   type PLifted (PAsData a) = PAsDataLifted a

--- a/Plutarch/DataRepr.hs
+++ b/Plutarch/DataRepr.hs
@@ -28,7 +28,7 @@ import Plutarch.Prelude
 import qualified Plutus.V1.Ledger.Api as Ledger
 import qualified PlutusCore as PLC
 
-data PDataList (as :: [k -> Type]) (s :: k)
+data PDataList (as :: [PType]) (s :: S)
 
 pdhead :: Term s (PDataList (a : as) :--> PAsData a)
 pdhead = phoistAcyclic $ pforce $ punsafeBuiltin PLC.HeadList
@@ -36,8 +36,8 @@ pdhead = phoistAcyclic $ pforce $ punsafeBuiltin PLC.HeadList
 pdtail :: Term s (PDataList (a : as) :--> PDataList as)
 pdtail = phoistAcyclic $ pforce $ punsafeBuiltin PLC.TailList
 
-type PDataRepr :: [[k -> Type]] -> k -> Type
-data PDataRepr (defs :: [[k -> Type]]) (s :: k)
+type PDataRepr :: [[PType]] -> PType
+data PDataRepr (defs :: [[PType]]) (s :: S)
 
 pasData :: Term s (PDataRepr _) -> Term s PData
 pasData = punsafeCoerce
@@ -72,7 +72,7 @@ pindexDataList n =
     ind :: Term s PInteger
     ind = fromInteger $ toInteger $ natVal n
 
-data DataReprHandlers (out :: k -> Type) (def :: [[k -> Type]]) (s :: k) where
+data DataReprHandlers (out :: PType) (def :: [[PType]]) (s :: S) where
   DRHNil :: DataReprHandlers out '[] s
   DRHCons :: (Term s (PDataList def) -> Term s out) -> DataReprHandlers out defs s -> DataReprHandlers out (def : defs) s
 
@@ -122,10 +122,10 @@ pmatchDataRepr d handlers =
               handler
               $ go common (idx + 1) rest constr
 
-newtype PIsDataReprInstances (a :: k -> Type) (h :: Type) (s :: k) = PIsDataReprInstances (a s)
+newtype PIsDataReprInstances (a :: PType) (h :: Type) (s :: S) = PIsDataReprInstances (a s)
 
-class (PMatch a, PIsData a) => PIsDataRepr (a :: k -> Type) where
-  type PIsDataReprRepr a :: [[k -> Type]]
+class (PMatch a, PIsData a) => PIsDataRepr (a :: PType) where
+  type PIsDataReprRepr a :: [[PType]]
   pmatchRepr :: forall s b. Term s (PDataRepr (PIsDataReprRepr a)) -> (a s -> Term s b) -> Term s b
 
 instance PIsDataRepr a => PIsData (PIsDataReprInstances a h) where

--- a/Plutarch/Either.hs
+++ b/Plutarch/Either.hs
@@ -3,7 +3,7 @@ module Plutarch.Either (PEither (..)) where
 import Plutarch (PlutusType (PInner, pcon', pmatch'))
 import Plutarch.Prelude
 
-data PEither (a :: k -> Type) (b :: k -> Type) (s :: k) = PLeft (Term s a) | PRight (Term s b)
+data PEither (a :: PType) (b :: PType) (s :: S) = PLeft (Term s a) | PRight (Term s b)
 
 instance PlutusType (PEither a b) where
   type PInner (PEither a b) c = (a :--> c) :--> (b :--> c) :--> c

--- a/Plutarch/Internal.hs
+++ b/Plutarch/Internal.hs
@@ -24,6 +24,8 @@ module Plutarch.Internal (
   RawTerm (..),
   TermCont (..),
   TermResult (TermResult, getDeps, getTerm),
+  S,
+  PType,
 ) where
 
 import Crypto.Hash (Context, Digest, hashFinalize, hashInit, hashUpdate)
@@ -100,6 +102,13 @@ mapTerm f (TermResult t d) = TermResult (f t) d
 
 mkTermRes :: RawTerm -> TermResult
 mkTermRes r = TermResult r []
+
+-- | Type of `s`.
+data S
+
+-- | Shorthand for Plutarch types.
+type PType = S -> Type
+
 {- $term
  Source: Unembedding Domain-Specific Languages by Robert Atkey, Sam Lindley, Jeremy Yallop
  Thanks!
@@ -114,17 +123,17 @@ mkTermRes r = TermResult r []
  de-Bruijn index needed to reach its own level given the level it itself is
  instantiated with.
 -}
-newtype Term (s :: k) (a :: k -> Type) = Term {asRawTerm :: Natural -> TermResult}
+newtype Term (s :: S) (a :: PType) = Term {asRawTerm :: Natural -> TermResult}
 
 {- |
   *Closed* terms with no free variables.
 -}
-type ClosedTerm (a :: k -> Type) = forall (s :: k). Term s a
+type ClosedTerm (a :: PType) = forall (s :: S). Term s a
 
-data (:-->) (a :: k -> Type) (b :: k -> Type) (s :: k)
+data (:-->) (a :: PType) (b :: PType) (s :: S)
 infixr 0 :-->
 
-data PDelayed (a :: k -> Type) (s :: k)
+data PDelayed (a :: PType) (s :: S)
 
 {- |
   Lambda abstraction.

--- a/Plutarch/List.hs
+++ b/Plutarch/List.hs
@@ -39,15 +39,16 @@ module Plutarch.List (
   pany,
 ) where
 
-import Plutarch
-import Plutarch.Bool (PBool (..), PEq (..), pif, (#&&), (#||))
+import Plutarch (PInner, PlutusType, pcon', pmatch')
+import Plutarch.Bool (PBool (PFalse, PTrue), PEq, pif, (#&&), (#==), (#||))
 import Plutarch.Integer (PInteger)
-import Plutarch.Pair (PPair (..))
+import Plutarch.Lift (pconstant)
+import Plutarch.Pair (PPair (PPair))
 import Plutarch.Prelude
 
 import Data.Kind
 
-data PList (a :: k -> Type) (s :: k)
+data PList (a :: PType) (s :: S)
   = PSCons (Term s a) (Term s (PList a))
   | PSNil
 
@@ -69,8 +70,8 @@ instance PEq a => PEq (PList a) where
 type PIsListLike list a = (PListLike list, PElemConstraint list a)
 
 -- | Plutarch types that behave like lists.
-class PListLike (list :: (k -> Type) -> k -> Type) where
-  type PElemConstraint list (a :: k -> Type) :: Constraint
+class PListLike (list :: (PType) -> PType) where
+  type PElemConstraint list (a :: PType) :: Constraint
 
   -- | Canonical eliminator for list-likes.
   pelimList ::

--- a/Plutarch/Maybe.hs
+++ b/Plutarch/Maybe.hs
@@ -7,7 +7,7 @@ import Plutarch (PlutusType (PInner, pcon', pmatch'))
 import Plutarch.Prelude
 
 -- | Plutus Maybe type, with Scott-encoded repr
-data PMaybe (a :: k -> Type) (s :: k) = PJust (Term s a) | PNothing
+data PMaybe (a :: PType) (s :: S) = PJust (Term s a) | PNothing
 
 instance PlutusType (PMaybe a) where
   type PInner (PMaybe a) b = (a :--> b) :--> PDelayed b :--> b

--- a/Plutarch/Pair.hs
+++ b/Plutarch/Pair.hs
@@ -11,7 +11,7 @@ import Plutarch.Prelude
 
   Note: This is represented differently than 'BuiltinPair'
 -}
-data PPair (a :: k -> Type) (b :: k -> Type) (s :: k) = PPair (Term s a) (Term s b)
+data PPair (a :: PType) (b :: PType) (s :: S) = PPair (Term s a) (Term s b)
 
 instance PlutusType (PPair a b) where
   type PInner (PPair a b) c = (a :--> b :--> c) :--> c

--- a/Plutarch/Prelude.hs
+++ b/Plutarch/Prelude.hs
@@ -17,6 +17,8 @@ module Plutarch.Prelude (
   pto,
   pfix,
   Type,
+  S,
+  PType,
 ) where
 
 import Prelude ()

--- a/Plutarch/Rec.hs
+++ b/Plutarch/Rec.hs
@@ -14,6 +14,7 @@ import Data.Monoid (Dual (Dual, getDual), Endo (Endo, appEndo), Sum (Sum, getSum
 import Numeric.Natural (Natural)
 import Plutarch (PCon, pcon, phoistAcyclic, plam, punsafeCoerce, (#), (:-->))
 import Plutarch.Internal (
+  PType,
   RawTerm (RApply, RLamAbs, RVar),
   Term (Term, asRawTerm),
   TermResult (TermResult, getDeps, getTerm),
@@ -23,7 +24,7 @@ import qualified Rank2
 
 newtype PRecord r s = PRecord {getRecord :: r (Term s)}
 
-type family ScottEncoded (r :: ((k -> Type) -> Type) -> Type) (a :: k -> Type) :: k -> Type
+type family ScottEncoded (r :: ((PType) -> Type) -> Type) (a :: PType) :: PType
 newtype ScottArgument r s t = ScottArgument {getScott :: Term s (ScottEncoded r t)}
 type ScottEncoding r t = ScottEncoded r t :--> t
 

--- a/bench/Main.hs
+++ b/bench/Main.hs
@@ -5,6 +5,7 @@ import Plutarch
 import Plutarch.Bool
 import Plutarch.Builtin
 import Plutarch.Integer
+import Plutarch.Lift
 import qualified Plutarch.List as List
 
 main :: IO ()

--- a/examples/Examples/Api.hs
+++ b/examples/Examples/Api.hs
@@ -10,6 +10,7 @@ import Plutarch.Api.V1 (
  )
 import Plutarch.Builtin (PAsData, PBuiltinList)
 import Plutarch.DataRepr (pindexDataList)
+import Plutarch.Lift (pconstant)
 
 import Plutus.V1.Ledger.Api (
   Address (..),

--- a/examples/Examples/LetRec.hs
+++ b/examples/Examples/LetRec.hs
@@ -41,7 +41,7 @@ $(deriveScottEncoded ''SampleRecord)
 $(Rank2.TH.deriveAll ''SampleRecord)
 $(Rank2.TH.deriveAll ''EvenOdd)
 
-sampleRecur :: Term (s :: k) (ScottEncoding SampleRecord (t :: k -> Type))
+sampleRecur :: Term (s :: S) (ScottEncoding SampleRecord (t :: PType))
 sampleRecur =
   letrec $
     const
@@ -51,7 +51,7 @@ sampleRecur =
         , sampleString = "Hello, World!"
         }
 
-evenOdd :: Term (s :: k) (ScottEncoding EvenOdd (t :: k -> Type))
+evenOdd :: Term (s :: S) (ScottEncoding EvenOdd (t :: PType))
 evenOdd = letrec evenOddRecursion
   where
     evenOddRecursion :: EvenOdd (Term s) -> EvenOdd (Term s)

--- a/examples/Examples/List.hs
+++ b/examples/Examples/List.hs
@@ -9,6 +9,7 @@ import Plutarch
 import Plutarch.Bool (pnot, (#<), (#==))
 import Plutarch.Builtin (PBuiltinList (..))
 import Plutarch.Integer
+import Plutarch.Lift
 import Plutarch.List
 
 --------------------------------------------------------------------------------

--- a/examples/Examples/PlutusType.hs
+++ b/examples/Examples/PlutusType.hs
@@ -12,7 +12,7 @@ import Utils
 {- |
   A Sum type, which can be encoded as an Enum
 -}
-data AB (s :: k) = A | B
+data AB (s :: S) = A | B
 
 {- |
   AB is encoded as an Enum, using values of PInteger

--- a/examples/Main.hs
+++ b/examples/Main.hs
@@ -11,7 +11,7 @@ import qualified Data.ByteString as BS
 import Data.Maybe (fromJust)
 import qualified Examples.List as List
 import Examples.Tracing (traceTests)
-import Plutarch (POpaque, pconstant, plift', popaque, printTerm, punsafeBuiltin)
+import Plutarch (POpaque, popaque, printTerm, punsafeBuiltin)
 import Plutarch.Api.V1 (PScriptPurpose (PMinting))
 import Plutarch.Bool (PBool (PFalse, PTrue), pand, pif, pnot, por, (#&&), (#<), (#<=), (#==), (#||))
 import Plutarch.Builtin (PBuiltinList (..), PBuiltinPair, PData, pdata)
@@ -19,6 +19,7 @@ import Plutarch.ByteString (PByteString, pconsBS, phexByteStr, pindexBS, plength
 import Plutarch.Either (PEither (PLeft, PRight))
 import Plutarch.Integer (PInteger)
 import Plutarch.Internal (punsafeConstantInternal)
+import Plutarch.Lift (pconstant, plift')
 import Plutarch.Prelude
 import Plutarch.String (PString)
 import Plutarch.Unit (PUnit (..))

--- a/examples/Utils.hs
+++ b/examples/Utils.hs
@@ -16,13 +16,13 @@ import qualified PlutusCore.Evaluation.Machine.ExMemory as ExMemory
 --import Shrink (shrinkScript)
 import Test.Tasty.HUnit
 
-newtype EvalImpl = EvalImpl {runEvalImpl :: forall k (a :: k -> Type). HasCallStack => ClosedTerm a -> IO Scripts.Script}
-newtype EqualImpl = EqualImpl {runEqualImpl :: forall k (a :: k -> Type) (b :: k -> Type). HasCallStack => ClosedTerm a -> ClosedTerm b -> Assertion}
-newtype Equal'Impl = Equal'Impl {runEqual'Impl :: forall k (a :: k -> Type). HasCallStack => ClosedTerm a -> String -> Assertion}
-newtype FailsImpl = FailsImpl {runFailsImpl :: forall k (a :: k -> Type). HasCallStack => ClosedTerm a -> Assertion}
+newtype EvalImpl = EvalImpl {runEvalImpl :: forall k (a :: PType). HasCallStack => ClosedTerm a -> IO Scripts.Script}
+newtype EqualImpl = EqualImpl {runEqualImpl :: forall k (a :: PType) (b :: PType). HasCallStack => ClosedTerm a -> ClosedTerm b -> Assertion}
+newtype Equal'Impl = Equal'Impl {runEqual'Impl :: forall k (a :: PType). HasCallStack => ClosedTerm a -> String -> Assertion}
+newtype FailsImpl = FailsImpl {runFailsImpl :: forall k (a :: PType). HasCallStack => ClosedTerm a -> Assertion}
 newtype ExpectImpl = ExpectImpl {runExpectImpl :: forall (k :: Type). HasCallStack => ClosedTerm @k PBool -> Assertion}
-newtype ThrowsImpl = ThrowsImpl {runThrowsImpl :: forall k (a :: k -> Type). ClosedTerm a -> Assertion}
-newtype TracesImpl = TracesImpl {runTracesImpl :: forall k (a :: k -> Type). ClosedTerm a -> [Text] -> Assertion}
+newtype ThrowsImpl = ThrowsImpl {runThrowsImpl :: forall k (a :: PType). ClosedTerm a -> Assertion}
+newtype TracesImpl = TracesImpl {runTracesImpl :: forall k (a :: PType). ClosedTerm a -> [Text] -> Assertion}
 
 data Tester = Tester
   { evalImpl :: EvalImpl
@@ -143,7 +143,7 @@ shrinkTester =
 
 eval :: (HasCallStack, HasTester) => ClosedTerm a -> IO Scripts.Script
 eval = runEvalImpl (evalImpl ?tester)
-equal :: forall k (a :: k -> Type) (b :: k -> Type). (HasCallStack, HasTester) => ClosedTerm @k a -> ClosedTerm @k b -> Assertion
+equal :: forall k (a :: PType) (b :: PType). (HasCallStack, HasTester) => ClosedTerm @k a -> ClosedTerm @k b -> Assertion
 equal x y = runEqualImpl (equalImpl ?tester) x y
 equal' :: (HasCallStack, HasTester) => ClosedTerm a -> String -> Assertion
 equal' = runEqual'Impl (equal'Impl ?tester)

--- a/flake.nix
+++ b/flake.nix
@@ -43,6 +43,81 @@
 
   outputs = inputs@{ self, nixpkgs, haskell-nix, plutus, flake-compat-ci, ... }:
     let
+      extraSources = [
+        {
+          src = inputs.protolude;
+          subdirs = [ "." ];
+        }
+        {
+          src = inputs.foundation;
+          subdirs = [
+            "foundation"
+            "basement"
+          ];
+        }
+        {
+          src = inputs.cardano-prelude;
+          subdirs = [
+            "cardano-prelude"
+            # "cardano-prelude-test"
+          ];
+        }
+        {
+          src = inputs.hs-memory;
+          subdirs = [ "." ];
+        }
+        {
+          src = inputs.cardano-crypto;
+          subdirs = [ "." ];
+        }
+        {
+          src = inputs.cryptonite;
+          subdirs = [ "." ];
+        }
+        {
+          src = inputs.flat;
+          subdirs = [ "." ];
+        }
+        {
+          src = inputs.cardano-base;
+          subdirs = [
+           # "base-deriving-via"
+            "binary"
+           # "binary/test"
+           "cardano-crypto-class"
+           # "cardano-crypto-praos"
+           # "cardano-crypto-tests"
+           # "measures"
+           # "orphans-deriving-via"
+           # "slotting"
+           # "strict-containers"
+          ];
+        }
+        {
+          src = inputs.sized-functors;
+          subdirs = [ "." ];
+        }
+        {
+          src = inputs.th-extras;
+          subdirs = [ "." ];
+        }
+        {
+          src = inputs.plutus;
+          subdirs = [
+            #"plutus-benchmark"
+            "plutus-core"
+            #"plutus-errors"
+            "plutus-ledger-api"
+            #"plutus-metatheory"
+            "plutus-tx"
+            #"plutus-tx-plugin"
+            "prettyprinter-configurable"
+            "word-array"
+            #"stubs/plutus-ghc-stub"
+          ];
+        }
+      ];
+
       supportedSystems = with nixpkgs.lib.systems.supported; tier1 ++ tier2 ++ tier3;
 
       perSystem = nixpkgs.lib.genAttrs supportedSystems;
@@ -57,92 +132,7 @@
           src = ./.;
           compiler-nix-name = "ghc921";
           cabalProjectFileName = "cabal.project";
-          extraSources = [
-            {
-              src = inputs.protolude;
-              subdirs = [ "." ];
-            }
-            {
-              src = inputs.foundation;
-              subdirs = [
-                "foundation"
-                "basement"
-              ];
-            }
-            {
-              src = inputs.cardano-prelude;
-              subdirs = [
-                "cardano-prelude"
-                # "cardano-prelude-test"
-              ];
-            }
-            {
-              src = inputs.hs-memory;
-              subdirs = [ "." ];
-            }
-            {
-              src = inputs.cardano-crypto;
-              subdirs = [ "." ];
-            }
-            {
-              src = inputs.cryptonite;
-              subdirs = [ "." ];
-            }
-            {
-              src = inputs.flat;
-              subdirs = [ "." ];
-            }
-            {
-              src = inputs.cardano-base;
-              subdirs = [
-               # "base-deriving-via"
-                "binary"
-               # "binary/test"
-               "cardano-crypto-class"
-               # "cardano-crypto-praos"
-               # "cardano-crypto-tests"
-               # "measures"
-               # "orphans-deriving-via"
-               # "slotting"
-               # "strict-containers"
-              ];
-            }
-            {
-              src = inputs.sized-functors;
-              subdirs = [ "." ];
-            }
-            {
-              src = inputs.th-extras;
-              subdirs = [ "." ];
-            }
-            {
-              src = inputs.plutus;
-              subdirs = [
-                #"plutus-benchmark"
-                "plutus-core"
-                #"plutus-errors"
-                "plutus-ledger-api"
-                #"plutus-metatheory"
-                "plutus-tx"
-                #"plutus-tx-plugin"
-                "prettyprinter-configurable"
-                "word-array"
-                #"stubs/plutus-ghc-stub"
-              ];
-            }
-          ];
-          /*
-          extraSources = [
-            {
-              src = inputs.Win32-network;
-              subdirs = [ "." ];
-            }
-            {
-              src = inputs.Shrinker;
-              subdirs = [ "." "testing" ];
-            }
-          ];
-          */
+          inherit extraSources;
           modules = [{
             packages = {
               basement.src = "${inputs.foundation}/basement";
@@ -202,8 +192,6 @@
 
             additional = ps: [
               ps.plutus-ledger-api
-              #ps.plutus-tx
-              #ps.plutus-ledger-api
               #ps.shrinker
               #ps.shrinker-testing
             ];
@@ -227,6 +215,8 @@
           ;
     in
     {
+      inherit extraSources;
+
       project = perSystem projectFor;
       flake = perSystem (system: (projectFor system).flake {});
 


### PR DESCRIPTION
To migrate your code, a good first step is:

```sh
find -type f -name '*.hs' ! -path '*/dist-newstyle/*' -exec sed -i -e 's/k -> Type/PType/g' -e 's/s :: k/s :: S/g' {} +
```

If you're using type applications, some functions will now need fewer type applications.
