### PR TITLE
PLift bidirectionality

### DIFF
--- a/Plutarch/Bool.hs
+++ b/Plutarch/Bool.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 module Plutarch.Bool (
   PBool (..),
@@ -16,15 +17,15 @@ module Plutarch.Bool (
 ) where
 
 import Plutarch (PlutusType (PInner, pcon', pmatch'), punsafeBuiltin)
-import Plutarch.Lift (DerivePConstant, DerivePLiftViaCoercible, PConstant, PConstanted, PLifted, PLiftedRepr, PUnsafeLiftDecl, pconstant, pliftFromRepr, pliftToRepr)
+import Plutarch.Lift (DerivePConstantViaCoercible (DerivePConstantViaCoercible), PConstant, PLifted, PUnsafeLiftDecl, pconstant)
 import Plutarch.Prelude
 import qualified PlutusCore as PLC
 
 -- | Plutus 'BuiltinBool'
 data PBool (s :: S) = PTrue | PFalse
-  deriving (PUnsafeLiftDecl) via (DerivePLiftViaCoercible Bool PBool Bool)
 
-deriving via (DerivePConstant Bool) PBool instance (PConstant Bool)
+instance PUnsafeLiftDecl PBool where type PLifted PBool = Bool
+deriving via (DerivePConstantViaCoercible Bool PBool Bool) instance (PConstant Bool)
 
 instance PlutusType PBool where
   type PInner PBool _ = PBool

--- a/Plutarch/Bool.hs
+++ b/Plutarch/Bool.hs
@@ -16,13 +16,15 @@ module Plutarch.Bool (
 ) where
 
 import Plutarch (PlutusType (PInner, pcon', pmatch'), punsafeBuiltin)
-import Plutarch.Lift (DerivePLiftViaCoercible, PUnsafeLiftDecl, pconstant)
+import Plutarch.Lift (DerivePConstant, DerivePLiftViaCoercible, PConstant, PConstanted, PLifted, PLiftedRepr, PUnsafeLiftDecl, pconstant, pliftFromRepr, pliftToRepr)
 import Plutarch.Prelude
 import qualified PlutusCore as PLC
 
 -- | Plutus 'BuiltinBool'
-data PBool s = PTrue | PFalse
-  deriving (PUnsafeLiftDecl Bool) via (DerivePLiftViaCoercible Bool PBool Bool)
+data PBool (s :: S) = PTrue | PFalse
+  deriving (PUnsafeLiftDecl) via (DerivePLiftViaCoercible Bool PBool Bool)
+
+deriving via (DerivePConstant Bool) PBool instance (PConstant Bool)
 
 instance PlutusType PBool where
   type PInner PBool _ = PBool

--- a/Plutarch/Builtin.hs
+++ b/Plutarch/Builtin.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 -- This should have been called Plutarch.Data...
 module Plutarch.Builtin (
@@ -26,7 +27,7 @@ import Plutarch (PlutusType (..), punsafeBuiltin, punsafeCoerce)
 import Plutarch.Bool (PBool (..), PEq, (#==))
 import Plutarch.ByteString (PByteString)
 import Plutarch.Integer (PInteger)
-import Plutarch.Lift (DerivePLiftViaCoercible, PLift, PLifted, PLiftedRepr, PUnsafeLiftDecl, pconstant, pliftFromRepr, pliftToRepr)
+import Plutarch.Lift (DerivePConstantViaCoercible (DerivePConstantViaCoercible), PConstant, PConstantRepr, PConstanted, PLift, PLifted, PUnsafeLiftDecl, pconstant, pconstantFromRepr, pconstantToRepr)
 import Plutarch.List (PListLike (..), plistEquals)
 import Plutarch.Prelude
 import qualified PlutusCore as PLC
@@ -35,14 +36,17 @@ import PlutusTx (Data)
 -- | Plutus 'BuiltinPair'
 data PBuiltinPair (a :: PType) (b :: PType) (s :: S)
 
--- FIXME: figure out good way of deriving this
-instance (PUnsafeLiftDecl ah a, PUnsafeLiftDecl bh b) => PUnsafeLiftDecl (ah, bh) (PBuiltinPair a b) where
-  type PLiftedRepr (PBuiltinPair a b) = (PLiftedRepr a, PLiftedRepr b)
+instance (PLift a, PLift b) => PUnsafeLiftDecl (PBuiltinPair a b) where
   type PLifted (PBuiltinPair a b) = (PLifted a, PLifted b)
-  pliftToRepr (x, y) = (pliftToRepr @_ @a x, pliftToRepr @_ @b y)
-  pliftFromRepr (x, y) = do
-    x' <- pliftFromRepr @_ @a x
-    y' <- pliftFromRepr @_ @b y
+
+-- FIXME: figure out good way of deriving this
+instance (PConstant a, PConstant b) => PConstant (a, b) where
+  type PConstantRepr (a, b) = (PConstantRepr a, PConstantRepr b)
+  type PConstanted (a, b) = PBuiltinPair (PConstanted a) (PConstanted b)
+  pconstantToRepr (x, y) = (pconstantToRepr x, pconstantToRepr y)
+  pconstantFromRepr (x, y) = do
+    x' <- pconstantFromRepr @a x
+    y' <- pconstantFromRepr @b y
     Just (x', y')
 
 pfstBuiltin :: Term s (PBuiltinPair a b :--> a)
@@ -78,11 +82,14 @@ pnullBuiltin = phoistAcyclic $ pforce $ punsafeBuiltin PLC.NullList
 pconsBuiltin :: Term s (a :--> PBuiltinList a :--> PBuiltinList a)
 pconsBuiltin = phoistAcyclic $ pforce $ punsafeBuiltin PLC.MkCons
 
-instance PUnsafeLiftDecl ah a => PUnsafeLiftDecl [ah] (PBuiltinList a) where
+instance PConstant a => PConstant [a] where
+  type PConstantRepr [a] = [PConstantRepr a]
+  type PConstanted [a] = PBuiltinList (PConstanted a)
+  pconstantToRepr x = pconstantToRepr <$> x
+  pconstantFromRepr x = traverse (pconstantFromRepr @a) x
+
+instance PUnsafeLiftDecl a => PUnsafeLiftDecl (PBuiltinList a) where
   type PLifted (PBuiltinList a) = [PLifted a]
-  type PLiftedRepr (PBuiltinList a) = [PLiftedRepr a]
-  pliftToRepr x = pliftToRepr @_ @a <$> x
-  pliftFromRepr x = traverse (pliftFromRepr @_ @a) x
 
 instance PLift a => PlutusType (PBuiltinList a) where
   type PInner (PBuiltinList a) _ = PBuiltinList a
@@ -116,7 +123,9 @@ data PData s
   | PDataList (Term s (PBuiltinList PData))
   | PDataInteger (Term s PInteger)
   | PDataByteString (Term s PByteString)
-  deriving (PUnsafeLiftDecl Data) via (DerivePLiftViaCoercible Data PData Data)
+
+instance PUnsafeLiftDecl PData where type PLifted PData = Data
+deriving via (DerivePConstantViaCoercible Data PData Data) instance (PConstant Data)
 
 instance PEq PData where
   x #== y = punsafeBuiltin PLC.EqualsData # x # y
@@ -154,11 +163,13 @@ data PAsData (a :: PType) (s :: S)
 
 data PAsDataLifted (a :: PType)
 
-instance PUnsafeLiftDecl (PAsDataLifted a) (PAsData a) where
-  type PLifted (PAsData a) = PAsDataLifted a
-  type PLiftedRepr (PAsData a) = Data
-  pliftToRepr = \case
-  pliftFromRepr _ = Nothing
+instance PConstant (PAsDataLifted a) where
+  type PConstantRepr (PAsDataLifted a) = Data
+  type PConstanted (PAsDataLifted a) = PAsData a
+  pconstantToRepr = \case
+  pconstantFromRepr _ = Nothing
+
+instance PUnsafeLiftDecl (PAsData a) where type PLifted (PAsData a) = PAsDataLifted a
 
 pforgetData :: Term s (PAsData a) -> Term s PData
 pforgetData = punsafeCoerce

--- a/Plutarch/ByteString.hs
+++ b/Plutarch/ByteString.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 module Plutarch.ByteString (
   PByteString,
@@ -18,13 +19,15 @@ import GHC.Stack (HasCallStack)
 import Plutarch (punsafeBuiltin)
 import Plutarch.Bool (PEq, POrd, (#<), (#<=), (#==))
 import Plutarch.Integer (PInteger)
-import Plutarch.Lift (DerivePLiftViaCoercible, PUnsafeLiftDecl, pconstant)
+import Plutarch.Lift (DerivePConstantViaCoercible (DerivePConstantViaCoercible), PConstant, PLifted, PUnsafeLiftDecl, pconstant)
 import Plutarch.Prelude
 import qualified PlutusCore as PLC
 
 -- | Plutus 'BuiltinByteString'
 data PByteString s
-  deriving (PUnsafeLiftDecl ByteString) via (DerivePLiftViaCoercible ByteString PByteString ByteString)
+
+instance PUnsafeLiftDecl PByteString where type PLifted PByteString = ByteString
+deriving via (DerivePConstantViaCoercible ByteString PByteString ByteString) instance (PConstant ByteString)
 
 instance PEq PByteString where
   x #== y = punsafeBuiltin PLC.EqualsByteString # x # y

--- a/Plutarch/Integer.hs
+++ b/Plutarch/Integer.hs
@@ -1,16 +1,19 @@
 {-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 module Plutarch.Integer (PInteger, PIntegral (..)) where
 
 import Plutarch (punsafeBuiltin)
 import Plutarch.Bool (PEq, POrd, pif, (#<), (#<=), (#==))
-import Plutarch.Lift (DerivePLiftViaCoercible, PUnsafeLiftDecl, pconstant)
+import Plutarch.Lift (DerivePConstantViaCoercible (DerivePConstantViaCoercible), PConstant, PLifted, PUnsafeLiftDecl, pconstant)
 import Plutarch.Prelude
 import qualified PlutusCore as PLC
 
 -- | Plutus BuiltinInteger
 data PInteger s
-  deriving (PUnsafeLiftDecl Integer) via (DerivePLiftViaCoercible Integer PInteger Integer)
+
+instance PUnsafeLiftDecl PInteger where type PLifted PInteger = Integer
+deriving via (DerivePConstantViaCoercible Integer PInteger Integer) instance (PConstant Integer)
 
 class PIntegral a where
   pdiv :: Term s (a :--> a :--> a)

--- a/Plutarch/Internal.hs
+++ b/Plutarch/Internal.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE RoleAnnotations #-}
+
 module Plutarch.Internal (
   -- | $hoisted
   (:-->),
@@ -108,6 +110,8 @@ data S
 
 -- | Shorthand for Plutarch types.
 type PType = S -> Type
+
+type role Term phantom representational
 
 {- $term
  Source: Unembedding Domain-Specific Languages by Robert Atkey, Sam Lindley, Jeremy Yallop

--- a/Plutarch/String.hs
+++ b/Plutarch/String.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 module Plutarch.String (PString, pfromText, pencodeUtf8, pdecodeUtf8) where
 
@@ -8,13 +9,15 @@ import qualified Data.Text as Txt
 import Plutarch (punsafeBuiltin)
 import Plutarch.Bool (PEq, (#==))
 import Plutarch.ByteString (PByteString)
-import Plutarch.Lift (DerivePLiftViaCoercible, PUnsafeLiftDecl, pconstant)
+import Plutarch.Lift (DerivePConstantViaCoercible (DerivePConstantViaCoercible), PConstant, PLifted, PUnsafeLiftDecl, pconstant)
 import Plutarch.Prelude
 import qualified PlutusCore as PLC
 
 -- | Plutus 'BuiltinString' values
 data PString s
-  deriving (PUnsafeLiftDecl Text) via (DerivePLiftViaCoercible Text PString Text)
+
+instance PUnsafeLiftDecl PString where type PLifted PString = Text
+deriving via (DerivePConstantViaCoercible Text PString Text) instance (PConstant Text)
 
 {-# DEPRECATED pfromText "Use `pconstant` instead." #-}
 

--- a/Plutarch/Unit.hs
+++ b/Plutarch/Unit.hs
@@ -1,13 +1,15 @@
 {-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 module Plutarch.Unit (PUnit (..)) where
 
 import Plutarch (PlutusType (PInner, pcon', pmatch'), Term, pcon)
 import Plutarch.Bool (PBool (PFalse, PTrue), PEq, POrd, (#<), (#<=), (#==))
-import Plutarch.Lift (DerivePLiftViaCoercible, PUnsafeLiftDecl, pconstant)
+import Plutarch.Lift (DerivePConstantViaCoercible (DerivePConstantViaCoercible), PConstant, PLifted, PUnsafeLiftDecl, pconstant)
 
 data PUnit s = PUnit
-  deriving (PUnsafeLiftDecl ()) via (DerivePLiftViaCoercible () PUnit ())
+instance PUnsafeLiftDecl PUnit where type PLifted PUnit = ()
+deriving via (DerivePConstantViaCoercible () PUnit ()) instance (PConstant ())
 
 instance PlutusType PUnit where
   type PInner PUnit _ = PUnit

--- a/examples/Main.hs
+++ b/examples/Main.hs
@@ -19,7 +19,7 @@ import Plutarch.ByteString (PByteString, pconsBS, phexByteStr, pindexBS, plength
 import Plutarch.Either (PEither (PLeft, PRight))
 import Plutarch.Integer (PInteger)
 import Plutarch.Internal (punsafeConstantInternal)
-import Plutarch.Lift (pconstant, plift')
+import Plutarch.Lift (pconstant, plift)
 import Plutarch.Prelude
 import Plutarch.String (PString)
 import Plutarch.Unit (PUnit (..))
@@ -34,6 +34,8 @@ import qualified Examples.PlutusType as PlutusType
 import qualified Examples.Rationals as Rationals
 import qualified Examples.Recursion as Recursion
 import Utils
+
+import Data.Text (Text)
 
 main :: IO ()
 main = defaultMain $ testGroup "all tests" [standardTests] -- , shrinkTests ]
@@ -233,25 +235,25 @@ plutarchTests =
     , testGroup
         "Lifting of constants"
         [ testCase "plift on primitive types" $ do
-            plift' (pcon PTrue) @?= Right True
-            plift' (pcon PFalse) @?= Right False
+            plift (pcon PTrue) @?= True
+            plift (pcon PFalse) @?= False
         , testCase "pconstant on primitive types" $ do
-            plift' (pconstant @PBool False) @?= Right False
-            plift' (pconstant @PBool True) @?= Right True
+            plift (pconstant @PBool False) @?= False
+            plift (pconstant @PBool True) @?= True
         , testCase "plift on list and pair" $ do
-            plift' (pconstant @(PBuiltinList PInteger) [1, 2, 3]) @?= Right [1, 2, 3]
-            plift' (pconstant @(PBuiltinPair PString PInteger) ("IOHK", 42)) @?= Right ("IOHK", 42)
+            plift (pconstant ([1, 2, 3] :: [Integer])) @?= [1, 2, 3]
+            plift (pconstant ("IOHK" :: Text, 42 :: Integer)) @?= ("IOHK", 42)
         , testCase "plift on data" $ do
             let d :: PlutusTx.Data
                 d = PlutusTx.toData @(Either Bool Bool) $ Right False
-            plift' (pconstant @(PData) d) @?= Right d
+            plift (pconstant d) @?= d
         , testCase "plift on nested containers" $ do
             -- List of pairs
-            let v1 = [("IOHK", 42), ("Plutus", 31)]
-            plift' (pconstant @(PBuiltinList (PBuiltinPair PString PInteger)) v1) @?= Right v1
+            let v1 = [("IOHK", 42), ("Plutus", 31)] :: [(Text, Integer)]
+            plift (pconstant v1) @?= v1
             -- List of pair of lists
-            let v2 = [("IOHK", [1, 2, 3]), ("Plutus", [9, 8, 7])]
-            plift' (pconstant @(PBuiltinList (PBuiltinPair PString (PBuiltinList PInteger))) v2) @?= Right v2
+            let v2 = [("IOHK", [1, 2, 3]), ("Plutus", [9, 8, 7])] :: [(Text, [Integer])]
+            plift (pconstant v2) @?= v2
         ]
     , testGroup
         "Boolean operations"


### PR DESCRIPTION
This makes `pconstant True` be inferred to be of type `Term s PBool`.

There is however an issue: deriving via seems to work quite suboptimally.

We need two derives because there are two type classes now:
```haskell
data PBool (s :: S) = PTrue | PFalse
  deriving (PUnsafeLiftDecl) via (DerivePLiftViaCoercible Bool PBool Bool)

deriving via (DerivePConstant Bool) PBool instance (PConstant Bool)
```

The issue then is that the instance is:
```haskell
instance (PConstant h, PConstanted h ~ DerivePLiftViaCoercible h p r, Coercible h r, PLC.DefaultUni `PLC.Includes` r) => PUnsafeLiftDecl (DerivePLiftViaCoercible h p r) where
```
`PConstanted h ~ DerivePLiftViaCoercible h p r` fails to hold, because `PConstanted h` is set by another
derive. I'm not sure whether this is easy to fix.

The reason I switched away from functional dependencies is ironically that it seemed
easier to make newtype derives work.

Is there any solution that doesn't involve TH?