### PR TITLE
Update guide

### DIFF
--- a/docs/DEVGUIDE.md
+++ b/docs/DEVGUIDE.md
@@ -141,7 +141,7 @@ We have a [Plutus Core builtin functions reference](https://github.com/Plutonomi
 
 Most of the time, you'll be working with `BuiltinData`/`Data` - this is the type of the arguments that will be passed onto your script from the outside. This is the type of the datum, the redeemer and the script context. This is also the type of arguments you will be able to pass to a `Script`.
 
-Plutarch aims to hide these low level details from the user. Ideally, you will be using `PDataRepr` - this is essentially just `BuiltinData`, but it is typed at the Plutarch level.
+Plutarch aims to hide these low level details from the user. Ideally, you will be using `PDataRepr`/`PDataList` and `PAsData` - these are essentially just `BuiltinData`, but it is typed at the Plutarch level.
 
 If you want to work with `BuiltinData` directly however, which you may have to do during developing Plutarch, you can find all that you need to know at [Plutonomicon](https://github.com/Plutonomicon/plutonomicon/blob/main/builtin-data.md).
 

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -35,7 +35,7 @@
       - [Implementing `PLift`](#implementing-plift)
     - [PlutusType, PCon, and PMatch](#plutustype-pcon-and-pmatch)
     - [PListLike](#plistlike)
-    - [PIsDataRepr & PDataList](#pisdatarepr--pdatalist)
+    - [PIsDataRepr](#pisdatarepr)
       - [Implementing PIsDataRepr](#implementing-pisdatarepr)
   - [Working with Types](#working-with-types)
     - [PInteger](#pinteger)
@@ -47,9 +47,8 @@
     - [PList](#plist)
     - [PBuiltinPair](#pbuiltinpair)
     - [PAsData](#pasdata)
+    - [PDataRepr & PDataList](#pdatarepr--pdatalist)
     - [PData](#pdata)
-    - [PMaybe](#pmaybe)
-    - [PEither](#peither)
 - [Examples](#examples)
   - [Fibonacci number at given index](#fibonacci-number-at-given-index)
   - [Validator that always succeeds](#validator-that-always-succeeds)
@@ -604,7 +603,7 @@ On the other hand, if your type is represented as a `Data` under the hood (`Defa
 data PScriptPurpose s
   deriving (PLift) via (PIsDataReprInstances PScriptPurpose Ledger.ScriptPurpose)
 ```
-> Aside: `PDataReprInstances` also lets you derive `PMatch` and `PIsDataRepr` for your type!
+> Aside: `PIsDataReprInstances` also lets you derive `PMatch` and `PIsDataRepr` for your type!
 Similar to `PBuiltinType`, `PIsDataReprInstances` also takes in two types - the Plutarch type and its corresponding Haskell synonym.
 
 ### PlutusType, PCon, and PMatch
@@ -697,7 +696,7 @@ x = pcons # 1 #$ pcons # 2 #$ pcons # 3 # pnil
 ```
 The code is the same, we just changed the type annotation. Cool!
 
-### PIsDataRepr & PDataList
+### PIsDataRepr
 `PIsDataRepr` and `PDataList` are the user-facing parts of an absolute workhorse of a machinery for easily deconstructing `Constr` [`BuiltinData`/`Data`](https://github.com/Plutonomicon/plutonomicon/blob/main/builtin-data.md) values. It allows fully type safe matching on `Data` values, without embedding type information within the generated script - unlike PlutusTx.
 
 For example, `PScriptContext` - which is the Plutarch synonym to [`ScriptContext`](https://staging.plutus.iohkdev.io/doc/haddock/plutus-ledger-api/html/Plutus-V1-Ledger-Contexts.html#t:ScriptContext) - has a `PIsDataRepr` instance, this lets you easily keep track of its type and match on it-
@@ -952,20 +951,19 @@ You can also create a `PAsData` from a `PData`, but you lose specific type infor
 pdata :: Term s PData -> Term s (PAsData PData)
 ```
 
+### PDataRepr & PDataList
+TODO
+
+See: [`PIsDataRepr`](#pisdatarepr)
+
 ### PData
 This is a direct synonym to [`BuiltinData`/`Data`](https://github.com/Plutonomicon/plutonomicon/blob/main/builtin-data.md). As such, it doesn't keep track of what "species" of `Data` it actually is. Is it an `I` data? Is it a `B` data? Nobody can tell for sure!
 
-Consider using `PAsData` instead for simple cases, i.e cases other than `Constr`.
+Consider using [`PAsData`](#pasdata) instead for simple cases, i.e cases other than `Constr`.
 
-Consider using `PDataRepr` instead when dealing with ADTs, i.e `Constr` data values.
+Consider using [`PDataRepr`/`PDataList`](#pdatarepr--pdatalist) instead when dealing with ADTs, i.e `Constr` data values.
 
 You can find more information about `PData` at [Developers' Corner](./DEVGUIDE.md).
-
-### PMaybe
-TODO
-
-### PEither
-TODO
 
 # Examples
 Be sure to check out [Compiling and Running](#compiling-and-running) first!

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -633,7 +633,7 @@ deriving via (DerivePConstantViaCoercible Integer PInteger Integer) instance (PC
 `DerivePConstantViaCoercible` takes in 3 type parameters-
 * The Haskell type itself, for which `PConstant` is being implemented for.
 * The **direct** Plutarch synonym to the Haskell type.
-* Another Haskell type that the first param can be coerced into. TODO: more info
+* The Haskell type that the first param is *actually represented as*. The first param must be coercible to this type.
 
 Pretty simple! Let's check out `DerivePConstantViaNewtype` now-
 ```hs

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -563,7 +563,7 @@ pconstant :: PLift p => PLifted p -> Term s p
 
 plift :: (PLift p, HasCallStack) => ClosedTerm p -> PLifted p
 ```
-> Aside: `PLifted p` represents the Haskell synonym to the Plutarch type, `p`. Similarly, there is also `PConstanted h` - which represents the Plutarch synonym corresponding to a Haskell type. These type families may only be used for Plutarch types implementing `PConstant`/`PLift`.
+> Aside: `PLifted p` represents the Haskell synonym to the Plutarch type, `p`. Similarly, there is also `PConstanted h` - which represents the Plutarch synonym corresponding to the Haskell type, `h`. These type families may only be used for Plutarch types implementing `PConstant`/`PLift`.
 
 `pconstant` lets you build a Plutarch value from its corresponding Haskell synonym. For example, the haskell synonym of [`PBool`](#pbool) is [`Bool`](https://hackage.haskell.org/package/base-4.16.0.0/docs/Data-Bool.html#t:Bool).
 ```hs
@@ -648,8 +648,10 @@ deriving via (DerivePConstantViaNewtype Plutus.ValidatorHash PValidatorHash PByt
 `DerivePConstantViaNewtype` also takes in 3 type parameters-
 * The Haskell newtype itself, for which `PConstant` is being implemented for.
 * The Plutarch synonym to the Haskell type.
-* The actual type contained within the newtype.
-During runtime, `ValidatorHash` is actually just a `PByteString`, the same applies for `PValidatorHash`. So we give it the `newtype` treatment with `DerivePConstantViaNewtype`!
+* The actual Plutarch type corresponding to the Haskell type contained within the newtype.
+
+  E.g `ValidatorHash` is a newtype to a `ByteString`, which is synonymous to `PByteString`. In the same way, `PValidatorHash` is actually just a newtype to a `PByteString` term.
+During runtime, `ValidatorHash` is actually just a `ByteString`, the same applies for `PValidatorHash`. So we give it the `newtype` treatment with `DerivePConstantViaNewtype`!
 
 Finally, we have `DerivePConstantViaData` for `Data` values-
 ```hs

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -563,7 +563,7 @@ pconstant :: PLift p => PLifted p -> Term s p
 
 plift :: (PLift p, HasCallStack) => ClosedTerm p -> PLifted p
 ```
-> Aisde: `PLifted p` represents the Haskell synonym to the Plutarch type, `p`. Similarly, there is also `PConstanted h` - which represents the Plutarch synonym corresponding to a Haskell type. These type families may only be used for Plutarch types implementing `PConstant`/`PLift`.
+> Aside: `PLifted p` represents the Haskell synonym to the Plutarch type, `p`. Similarly, there is also `PConstanted h` - which represents the Plutarch synonym corresponding to a Haskell type. These type families may only be used for Plutarch types implementing `PConstant`/`PLift`.
 
 `pconstant` lets you build a Plutarch value from its corresponding Haskell synonym. For example, the haskell synonym of [`PBool`](#pbool) is [`Bool`](https://hackage.haskell.org/package/base-4.16.0.0/docs/Data-Bool.html#t:Bool).
 ```hs


### PR DESCRIPTION
* Add `do` syntax usage guide
* Update `PLift` section, added `PConstant`
* Remove `InDefaultUni` information, replace with `PLift`.

Closes #122 
Resolves a review comment in #99 