### PR TITLE
Fix instances for plam by making them overlapping and not incoherent

### DIFF
--- a/Plutarch.hs
+++ b/Plutarch.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE IncoherentInstances #-}
 
 module Plutarch (
   (PI.:-->),

--- a/Plutarch.hs
+++ b/Plutarch.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE UndecidableInstances #-}
-{-# LANGUAGE IncoherentInstances #-}
 
 module Plutarch (
   (PI.:-->),

--- a/Plutarch.hs
+++ b/Plutarch.hs
@@ -101,28 +101,22 @@ infixr 0 #$
 class PLamN a b | a -> b where
   plam :: a -> b
 
--- FIXME: This piece of code doesn't work unless you do (_ :: Term _ _)
-{-
-f :: Term s ((a :--> b) :--> b :--> b)
-f = plam $ \f _ -> f # perror
--}
-
-instance {-# INCOHERENT #-} (a' ~ Term s a, b' ~ Term s b) => PLamN (a' -> b') (Term s (a :--> b)) where
+instance (a' ~ Term s a, b' ~ Term s b) => PLamN (a' -> b') (Term s (a :--> b)) where
   plam = plam'
 
-instance {-# INCOHERENT #-} (a' ~ Term s a, b' ~ Term s b, c' ~ Term s c) => PLamN (a' -> b' -> c') (Term s (a :--> b :--> c)) where
+instance {-# OVERLAPPING #-} (a' ~ Term s a, b' ~ Term s b, c' ~ Term s c) => PLamN (a' -> b' -> c') (Term s (a :--> b :--> c)) where
   plam f = plam' $ \x -> plam (f x)
 
-instance {-# INCOHERENT #-} (a' ~ Term s a, b' ~ Term s b, c' ~ Term s c, d' ~ Term s d) => PLamN (a' -> b' -> c' -> d') (Term s (a :--> b :--> c :--> d)) where
+instance {-# OVERLAPPING #-} (a' ~ Term s a, b' ~ Term s b, c' ~ Term s c, d' ~ Term s d) => PLamN (a' -> b' -> c' -> d') (Term s (a :--> b :--> c :--> d)) where
   plam f = plam' $ \x -> plam (f x)
 
-instance {-# INCOHERENT #-} (a' ~ Term s a, b' ~ Term s b, c' ~ Term s c, d' ~ Term s d, e' ~ Term s e) => PLamN (a' -> b' -> c' -> d' -> e') (Term s (a :--> b :--> c :--> d :--> e)) where
+instance {-# OVERLAPPING #-} (a' ~ Term s a, b' ~ Term s b, c' ~ Term s c, d' ~ Term s d, e' ~ Term s e) => PLamN (a' -> b' -> c' -> d' -> e') (Term s (a :--> b :--> c :--> d :--> e)) where
   plam f = plam' $ \x -> plam (f x)
 
-instance {-# INCOHERENT #-} (a' ~ Term s a, b' ~ Term s b, c' ~ Term s c, d' ~ Term s d, e' ~ Term s e, f' ~ Term s f) => PLamN (a' -> b' -> c' -> d' -> e' -> f') (Term s (a :--> b :--> c :--> d :--> e :--> f)) where
+instance {-# OVERLAPPING #-} (a' ~ Term s a, b' ~ Term s b, c' ~ Term s c, d' ~ Term s d, e' ~ Term s e, f' ~ Term s f) => PLamN (a' -> b' -> c' -> d' -> e' -> f') (Term s (a :--> b :--> c :--> d :--> e :--> f)) where
   plam f = plam' $ \x -> plam (f x)
 
-instance {-# INCOHERENT #-} (a' ~ Term s a, b' ~ Term s b, c' ~ Term s c, d' ~ Term s d, e' ~ Term s e, f' ~ Term s f, g' ~ Term s g) => PLamN (a' -> b' -> c' -> d' -> e' -> f' -> g') (Term s (a :--> b :--> c :--> d :--> e :--> f :--> g)) where
+instance {-# OVERLAPPING #-} (a' ~ Term s a, b' ~ Term s b, c' ~ Term s c, d' ~ Term s d, e' ~ Term s e, f' ~ Term s f, g' ~ Term s g) => PLamN (a' -> b' -> c' -> d' -> e' -> f' -> g') (Term s (a :--> b :--> c :--> d :--> e :--> f :--> g)) where
   plam f = plam' $ \x -> plam (f x)
 
 pinl :: Term s a -> (Term s a -> Term s b) -> Term s b

--- a/Plutarch/Either.hs
+++ b/Plutarch/Either.hs
@@ -7,6 +7,6 @@ data PEither (a :: PType) (b :: PType) (s :: S) = PLeft (Term s a) | PRight (Ter
 
 instance PlutusType (PEither a b) where
   type PInner (PEither a b) c = (a :--> c) :--> (b :--> c) :--> c
-  pcon' (PLeft x) = plam $ \f (_ :: Term _ _) -> f # x
+  pcon' (PLeft x) = plam $ \f _ -> f # x
   pcon' (PRight y) = plam $ \_ g -> g # y
   pmatch' p f = p # plam (f . PLeft) # plam (f . PRight)

--- a/Plutarch/Maybe.hs
+++ b/Plutarch/Maybe.hs
@@ -12,6 +12,6 @@ data PMaybe (a :: PType) (s :: S) = PJust (Term s a) | PNothing
 instance PlutusType (PMaybe a) where
   type PInner (PMaybe a) b = (a :--> b) :--> PDelayed b :--> b
   pcon' :: forall s. PMaybe a s -> forall b. Term s (PInner (PMaybe a) b)
-  pcon' (PJust x) = plam $ \f (_ :: Term _ _) -> f # x
+  pcon' (PJust x) = plam $ \f _ -> f # x
   pcon' PNothing = plam $ \_ g -> pforce g
   pmatch' x f = x # plam (f . PJust) # pdelay (f PNothing)

--- a/Plutarch/Prelude.hs
+++ b/Plutarch/Prelude.hs
@@ -3,6 +3,7 @@ module Plutarch.Prelude (
   PDelayed,
   Term,
   plam,
+  plam',
   papp,
   pdelay,
   pforce,

--- a/examples/Examples/List.hs
+++ b/examples/Examples/List.hs
@@ -55,14 +55,15 @@ tests = do
           (pzipWith' (+) # integerList [1 .. 10] # integerList [1 .. 10])
             #== integerList (fmap (* 2) [1 .. 10])
     , testCase "pfoldl" $ do
+        let m :: Term _ (PInteger :--> PInteger :--> PInteger) = plam $ \x y -> x - y
         expect $
-          (pfoldl # plam (-) # 0 # integerList [1 .. 10])
+          (pfoldl # m # 0 # integerList [1 .. 10])
             #== pconstant (foldl (-) 0 [1 .. 10])
         expect $
           (pfoldl' (-) # 0 # integerList [1 .. 10])
             #== pconstant (foldl (-) 0 [1 .. 10])
         expect $
-          (pfoldl # plam (-) # 0 # integerList [])
+          (pfoldl # m # 0 # integerList [])
             #== pconstant 0
         expect $
           (pfoldl' (-) # 0 # integerList [])

--- a/examples/Main.hs
+++ b/examples/Main.hs
@@ -194,9 +194,9 @@ plutarchTests =
     , testCase "delay (force (delay 0)) => delay 0" $
         printTerm (pdelay . pforce . pdelay $ (0 :: Term s PInteger)) @?= "(program 1.0.0 (delay 0))"
     , testCase "id # 0 => 0" $
-        printTerm ((plam $ \x -> x) # (0 :: Term s PInteger)) @?= "(program 1.0.0 0)"
+        printTerm ((plam' $ \x -> x) # (0 :: Term s PInteger)) @?= "(program 1.0.0 0)"
     , testCase "hoist id 0 => 0" $
-        printTerm ((phoistAcyclic $ plam $ \x -> x) # (0 :: Term s PInteger)) @?= "(program 1.0.0 0)"
+        printTerm ((phoistAcyclic $ plam' $ \x -> x) # (0 :: Term s PInteger)) @?= "(program 1.0.0 0)"
     , testCase "hoist fstPair => fstPair" $
         printTerm (phoistAcyclic (punsafeBuiltin PLC.FstPair)) @?= "(program 1.0.0 fstPair)"
     , testCase "throws: hoist error" $ throws $ phoistAcyclic perror
@@ -230,7 +230,7 @@ plutarchTests =
         , testCase "λx y. sha2_256 x y =>!" $
             printTerm ((plam $ \x y -> punsafeBuiltin PLC.Sha2_256 # x # y)) @?= "(program 1.0.0 (\\i0 -> \\i0 -> sha2_256 i2 i1))"
         , testCase "let f = hoist (λx. x) in λx y. f x y => λx y. x y" $
-            printTerm ((plam $ \x y -> (phoistAcyclic $ plam $ \x -> x) # x # y)) @?= "(program 1.0.0 (\\i0 -> \\i0 -> i2 i1))"
+            printTerm ((plam $ \x y -> (phoistAcyclic $ plam' $ \x -> x) # x # y)) @?= "(program 1.0.0 (\\i0 -> \\i0 -> i2 i1))"
         , testCase "let f = hoist (λx. x True) in λx y. f x y => λx y. (λz. z True) x y" $
             printTerm ((plam $ \x y -> ((phoistAcyclic $ plam $ \x -> x # pcon PTrue)) # x # y)) @?= "(program 1.0.0 (\\i0 -> \\i0 -> (\\i0 -> i1 True) i2 i1))"
         ]

--- a/examples/Main.hs
+++ b/examples/Main.hs
@@ -194,9 +194,9 @@ plutarchTests =
     , testCase "delay (force (delay 0)) => delay 0" $
         printTerm (pdelay . pforce . pdelay $ (0 :: Term s PInteger)) @?= "(program 1.0.0 (delay 0))"
     , testCase "id # 0 => 0" $
-        printTerm ((plam' $ \x -> x) # (0 :: Term s PInteger)) @?= "(program 1.0.0 0)"
+        printTerm ((plam $ \x -> x) # (0 :: Term s PInteger)) @?= "(program 1.0.0 0)"
     , testCase "hoist id 0 => 0" $
-        printTerm ((phoistAcyclic $ plam' $ \x -> x) # (0 :: Term s PInteger)) @?= "(program 1.0.0 0)"
+        printTerm ((phoistAcyclic $ plam $ \x -> x) # (0 :: Term s PInteger)) @?= "(program 1.0.0 0)"
     , testCase "hoist fstPair => fstPair" $
         printTerm (phoistAcyclic (punsafeBuiltin PLC.FstPair)) @?= "(program 1.0.0 fstPair)"
     , testCase "throws: hoist error" $ throws $ phoistAcyclic perror
@@ -230,7 +230,7 @@ plutarchTests =
         , testCase "λx y. sha2_256 x y =>!" $
             printTerm ((plam $ \x y -> punsafeBuiltin PLC.Sha2_256 # x # y)) @?= "(program 1.0.0 (\\i0 -> \\i0 -> sha2_256 i2 i1))"
         , testCase "let f = hoist (λx. x) in λx y. f x y => λx y. x y" $
-            printTerm ((plam $ \x y -> (phoistAcyclic $ plam' $ \x -> x) # x # y)) @?= "(program 1.0.0 (\\i0 -> \\i0 -> i2 i1))"
+            printTerm ((plam $ \x y -> (phoistAcyclic $ plam $ \x -> x) # x # y)) @?= "(program 1.0.0 (\\i0 -> \\i0 -> i2 i1))"
         , testCase "let f = hoist (λx. x True) in λx y. f x y => λx y. (λz. z True) x y" $
             printTerm ((plam $ \x y -> ((phoistAcyclic $ plam $ \x -> x # pcon PTrue)) # x # y)) @?= "(program 1.0.0 (\\i0 -> \\i0 -> (\\i0 -> i1 True) i2 i1))"
         ]


### PR DESCRIPTION
I think I originally made these instances incoherent because they looked slightly
different, which somehow made OVERLAPPING not work. Then I changed them, without noticing
that I could make them coherent.