### PR TITLE
Enable api tests (partially)

### DIFF
--- a/examples/Examples/Api.hs
+++ b/examples/Examples/Api.hs
@@ -145,16 +145,16 @@ tests =
         ctx `equal'` ctx_compiled
     , testCase "getting txInfo" $ do
         plift (pfromData $ getTxInfo # ctx) @?= info
-    -- FIXME: Need 'PConstant' etc. instance for 'PValue'
-    -- , testCase "getting mint" $ do
-    --     plift (pfromData $ getMint #$ pfromData $ getTxInfo # ctx) @?= mint
-    , testCase "getting validator" $ do
+    , -- FIXME: Need 'PConstant' etc. instance for 'PValue'
+      -- , testCase "getting mint" $ do
+      --     plift (pfromData $ getMint #$ pfromData $ getTxInfo # ctx) @?= mint
+      testCase "getting validator" $ do
         plift (pfromData $ getValidator #$ pfromData $ getInputs #$ pfromData $ getTxInfo # ctx)
           @?= validator
-    -- FIXME: Need 'PlutusType' etc. instance for 'PMap'
-    -- , testCase "getting sym" $ do
-    --     plift (pfromData $ getSym #$ pfromData $ getMint #$ pfromData $ getTxInfo # ctx)
-    --       @?= sym
+          -- FIXME: Need 'PlutusType' etc. instance for 'PMap'
+          -- , testCase "getting sym" $ do
+          --     plift (pfromData $ getSym #$ pfromData $ getMint #$ pfromData $ getTxInfo # ctx)
+          --       @?= sym
     ]
 
 ctx_compiled :: String


### PR DESCRIPTION
This enables a few of the existing API tests that didn't work due to missing instances.

The examples that depend on `PMap` still don't work due to missing instances.

I'm going to add a more involved test as well - should ensure some level of stability.