### PR TITLE
Fix flake benchmark, use perf-diff instead of diff

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -450,11 +450,11 @@
         // {
           benchmark = {
             type = "app";
-            program = "${self.flake.${system}.packages."plutarch-benchmark:bench:perf"}/bin/perf";
+            program = "${self.flake.${system}.packages."plutarch-benchmark:bench:benchmark"}/bin/benchmark";
           };
-          perf-diff = {
+          benchmark-diff = {
             type = "app";
-            program = "${self.flake.${system}.packages."plutarch-benchmark:exe:perf-diff"}/bin/perf-diff";
+            program = "${self.flake.${system}.packages."plutarch-benchmark:exe:benchmark-diff"}/bin/benchmark-diff";
           };
         }
       );
@@ -486,7 +486,7 @@
                 echo
                 echo
 
-                nix --extra-experimental-features 'nix-command flakes' run .#perf-diff -- before.csv after.csv
+                nix --extra-experimental-features 'nix-command flakes' run .#benchmark-diff -- before.csv after.csv
               '';
             }
           );

--- a/flake.nix
+++ b/flake.nix
@@ -450,7 +450,7 @@
         // {
           benchmark = {
             type = "app";
-            program = "${self.flake.${system}.packages."plutarch:bench:perf"}/bin/perf";
+            program = "${self.flake.${system}.packages."plutarch-benchmark:bench:perf"}/bin/perf";
           };
         }
       );

--- a/flake.nix
+++ b/flake.nix
@@ -452,6 +452,10 @@
             type = "app";
             program = "${self.flake.${system}.packages."plutarch-benchmark:bench:perf"}/bin/perf";
           };
+          perf-diff = {
+            type = "app";
+            program = "${self.flake.${system}.packages."plutarch-benchmark:exe:perf-diff"}/bin/perf-diff";
+          };
         }
       );
       devShell = perSystem (system: self.flake.${system}.devShell);
@@ -471,10 +475,10 @@
                 cd plutarch
 
                 git checkout $(git merge-base origin/staging ${src.rev})
-                nix --extra-experimental-features 'nix-command flakes' run .#benchmark > before.csv
+                nix --extra-experimental-features 'nix-command flakes' run .#benchmark -- --csv > before.csv
 
                 git checkout ${src.rev}
-                nix --extra-experimental-features 'nix-command flakes' run .#benchmark > after.csv
+                nix --extra-experimental-features 'nix-command flakes' run .#benchmark -- --csv > after.csv
 
                 echo
                 echo
@@ -482,7 +486,7 @@
                 echo
                 echo
 
-                diff before.csv after.csv
+                nix --extra-experimental-features 'nix-command flakes' run .#perf-diff -- before.csv after.csv
               '';
             }
           );

--- a/plutarch-benchmark/benchmark-diff/Main.hs
+++ b/plutarch-benchmark/benchmark-diff/Main.hs
@@ -20,4 +20,4 @@ main =
 
 usage :: IO ()
 usage =
-  putStrLn "usage: perf-diff [old] [new]"
+  putStrLn "usage: benchmark-diff [old] [new]"

--- a/plutarch-benchmark/plutarch-benchmark.cabal
+++ b/plutarch-benchmark/plutarch-benchmark.cabal
@@ -92,7 +92,7 @@ library
 
   hs-source-dirs:  src
 
-benchmark perf
+benchmark benchmark
   import:         c
   type:           exitcode-stdio-1.0
   hs-source-dirs: bench
@@ -102,10 +102,9 @@ benchmark perf
     , plutarch
     , plutarch-benchmark
 
-executable perf-diff
+executable benchmark-diff
   import:         c
-  type:           exitcode-stdio-1.0
-  hs-source-dirs: perf-diff
+  hs-source-dirs: benchmark-diff
   main-is:        Main.hs
   build-depends:
     , base

--- a/plutarch-benchmark/src/Plutarch/Benchmark.hs
+++ b/plutarch-benchmark/src/Plutarch/Benchmark.hs
@@ -26,6 +26,7 @@ import Data.Coerce (coerce)
 import qualified Data.Map.Strict as Map
 import Data.Vector (Vector, (!))
 import qualified Data.Vector as Vector
+import System.Environment (getArgs)
 import Text.PrettyPrint.Boxes ((//))
 import qualified Text.PrettyPrint.Boxes as B
 
@@ -222,8 +223,11 @@ renderBudgetTable bs =
     ]
 
 benchMain :: [NamedBenchmark] -> IO ()
-benchMain benchmarks = do
-  let csv = Csv.encodeDefaultOrderedByName benchmarks
-  BSL.writeFile "bench.csv" csv
-  putStrLn "Wrote to bench.csv:"
-  putStrLn . B.render $ renderBudgetTable benchmarks
+benchMain benchmarks =
+  getArgs >>= \case
+    ["--csv"] -> BSL.putStr $ Csv.encodeDefaultOrderedByName benchmarks
+    _ -> do
+      let csv = Csv.encodeDefaultOrderedByName benchmarks
+      BSL.writeFile "bench.csv" csv
+      putStrLn "Wrote to bench.csv:"
+      putStrLn . B.render $ renderBudgetTable benchmarks


### PR DESCRIPTION
This should use perf-diff in the effect code now. 
cc: @MatthewCroughan