### PR TITLE
flake: always run benchmark-diff effect

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -516,6 +516,11 @@
           hci-effects = hercules-ci-effects.lib.withPkgs pkgs;
         in
         {
+          # Hercules 0.9 will allow us to calculate the merge-base so we can test all PRs.
+          # Right now we just hardcode this effect to test every commit against
+          # origin/staging. We set != "refs/head/master" so that merges into master don't
+          # cause a lot of unnecessary bogus benchmarks to appear in CI for the time
+          # being.
           benchmark-diff = hci-effects.runIf (src.ref != "refs/heads/master") (
             hci-effects.mkEffect {
               src = self;

--- a/flake.nix
+++ b/flake.nix
@@ -516,7 +516,7 @@
           hci-effects = hercules-ci-effects.lib.withPkgs pkgs;
         in
         {
-          benchmark-diff = hci-effects.runIf (src.ref == "refs/heads/staging") (
+          benchmark-diff = hci-effects.runIf (src.ref != "refs/heads/master") (
             hci-effects.mkEffect {
               src = self;
               buildInputs = with pkgs; [ git nixFlakes ];


### PR DESCRIPTION
Summary: Run benchmark-diff effect on _all commits_ instead of only those on staging.
Essentially, this change is necessary to make the workflow work as intended by https://github.com/Plutonomicon/plutarch/issues/123#issuecomment-1020583755.

Now all future PRs (like this one) will actually run the effects and show them in the checks.