### PR TITLE
Add `AllowAmbiguousTypes` to `Plutarch.Unsafe`

### DIFF
--- a/Plutarch/Unsafe.hs
+++ b/Plutarch/Unsafe.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+
 module Plutarch.Unsafe (
   PI.punsafeBuiltin,
   PI.punsafeCoerce,


### PR DESCRIPTION
Whoops, broke GHC 8.10.7 projects depending on plutarch.