### PR TITLE
Fix duplicate work in pmatch' impl of builtin lists

### DIFF
--- a/Plutarch/Builtin.hs
+++ b/Plutarch/Builtin.hs
@@ -128,7 +128,7 @@ instance PLift a => PlutusType (PBuiltinList a) where
   type PInner (PBuiltinList a) _ = PBuiltinList a
   pcon' (PCons x xs) = pconsBuiltin # x # xs
   pcon' PNil = pconstant []
-  pmatch' xs f =
+  pmatch' xs' f = plet xs' $ \xs ->
     pforce $
       pchooseListBuiltin
         # xs

--- a/examples/Examples/PlutusType.hs
+++ b/examples/Examples/PlutusType.hs
@@ -56,30 +56,16 @@ tests =
         "PlutusType instances sanity"
         -- TODO: Add more sanity tests here!
         [ testCase "PBuiltinList" $ do
-            pmatchTargetEvalBList $ pconstant [1 :: Integer, 2, 3, 4]
+            pmatchTargetEval $ pconstant [1 :: Integer, 2, 3, 4]
         ]
     ]
 
 -- CPP support isn't great in fourmolu.
 {- ORMOLU_DISABLE -}
 
--- | Make sure the target builtin list of 'pmatch' is not evaluated multiple times.
-pmatchTargetEvalBList :: (HasTester, PLift a) => ClosedTerm (PBuiltinList a) -> Assertion
-pmatchTargetEvalBList target = pmatch (ptrace (pconstant tag) target) (\case
-  PCons x xs -> plet x $ \_ -> plet xs $ \_ -> pconstant ()
-  PNil -> pconstant ())
-#ifdef Development
-  `traces` replicate 1 tag
-#else
-  `traces` []
-#endif
-  where
-    tag = "evaluating"
-
--- FIXME: This needs to fully "evaluate" (e.g evaluate in UPLC) the `x` within the `pmatch` handler.
 -- | Make sure the target of 'pmatch' is only evaluated once.
-_pmatchTargetEval :: HasTester => PlutusType p => ClosedTerm p -> Assertion
-_pmatchTargetEval target = pmatch (ptrace (pconstant tag) target) (\_ -> perror)
+pmatchTargetEval :: HasTester => PlutusType p => ClosedTerm p -> Assertion
+pmatchTargetEval target = pmatch (ptrace (pconstant tag) target) (\x -> plet (pcon x) $ \_ -> pconstant ())
 #ifdef Development
   `traces` replicate 1 tag
 #else

--- a/examples/Examples/PlutusType.hs
+++ b/examples/Examples/PlutusType.hs
@@ -1,11 +1,12 @@
+{-# LANGUAGE CPP #-}
+
 module Examples.PlutusType (AB (..), swap, tests) where
 
 import Plutarch
-import Plutarch.Bool (pif, (#==))
-import Plutarch.Integer (PInteger)
+import Plutarch.Prelude
 
 import Test.Tasty (TestTree, testGroup)
-import Test.Tasty.HUnit (testCase)
+import Test.Tasty.HUnit (Assertion, testCase)
 
 import Utils
 
@@ -39,13 +40,50 @@ swap x = pmatch x $ \case
 tests :: HasTester => TestTree
 tests =
   testGroup
-    "PlutusType examples"
-    [ testCase "A encoded as 0" $ do
-        pcon A `equal` (0 :: Term s PInteger)
-    , testCase "B encoded as 2" $ do
-        pcon B `equal` (1 :: Term s PInteger)
-    , testCase "swap A == B" $ do
-        swap (pcon A) `equal` pcon B
-    , testCase "swap B == A" $ do
-        swap (pcon B) `equal` pcon A
+    "PlutusType tests"
+    [ testGroup
+        "PlutusType examples"
+        [ testCase "A encoded as 0" $ do
+            pcon A `equal` (0 :: Term s PInteger)
+        , testCase "B encoded as 2" $ do
+            pcon B `equal` (1 :: Term s PInteger)
+        , testCase "swap A == B" $ do
+            swap (pcon A) `equal` pcon B
+        , testCase "swap B == A" $ do
+            swap (pcon B) `equal` pcon A
+        ]
+    , testGroup
+        "PlutusType instances sanity"
+        -- TODO: Add more sanity tests here!
+        [ testCase "PBuiltinList" $ do
+            pmatchTargetEvalBList $ pconstant [1 :: Integer, 2, 3, 4]
+        ]
     ]
+
+-- CPP support isn't great in fourmolu.
+{- ORMOLU_DISABLE -}
+
+-- | Make sure the target builtin list of 'pmatch' is not evaluated multiple times.
+pmatchTargetEvalBList :: (HasTester, PLift a) => ClosedTerm (PBuiltinList a) -> Assertion
+pmatchTargetEvalBList target = pmatch (ptrace (pconstant tag) target) (\case
+  PCons x xs -> plet x $ \_ -> plet xs $ \_ -> pconstant ()
+  PNil -> pconstant ())
+#ifdef Development
+  `traces` replicate 1 tag
+#else
+  `traces` []
+#endif
+  where
+    tag = "evaluating"
+
+-- FIXME: This needs to fully "evaluate" (e.g evaluate in UPLC) the `x` within the `pmatch` handler.
+-- | Make sure the target of 'pmatch' is only evaluated once.
+_pmatchTargetEval :: HasTester => PlutusType p => ClosedTerm p -> Assertion
+_pmatchTargetEval target = pmatch (ptrace (pconstant tag) target) (\_ -> perror)
+#ifdef Development
+  `traces` replicate 1 tag
+#else
+  `traces` []
+#endif
+  where
+    tag = "evaluating"


### PR DESCRIPTION
This also tries to set up a test for this kind of sanity tests.