### PR TITLE
Added an example using the proper monadic do with Cont

### DIFF
--- a/examples/Examples/Api.hs
+++ b/examples/Examples/Api.hs
@@ -1,5 +1,6 @@
 module Examples.Api (tests) where
 
+import Control.Monad.Trans.Cont (cont, runCont)
 import Plutarch
 import Plutarch.Api.V1 (
   PCredential,
@@ -170,6 +171,20 @@ checkSignatory = plam $ \ph ctx' ->
       -- Signature not present.
       perror
 
+checkSignatoryCont :: Term s (PPubKeyHash :--> PScriptContext :--> PUnit)
+checkSignatoryCont = plam $ \ph ctx' ->
+  pletFields @["txInfo", "purpose"] ctx' $ \ctx -> (`runCont` id) $ do
+    _ <- cont $ pmatch . pfromData $ ctx.purpose
+    let signatories = pfield @"signatories" # ctx.txInfo
+    cont $
+      const $
+        pif
+          (pelem # pdata ph # pfromData signatories)
+          -- Success!
+          (pconstant ())
+          -- Signature not present.
+          perror
+
 tests :: HasTester => TestTree
 tests =
   testGroup
@@ -189,6 +204,9 @@ tests =
         plift (pfromData $ getSym #$ pfromData $ getMint #$ getTxInfo # ctx) @?= sym
     , testCase "signatory validator" $ do
         () <$ traverse (\x -> succeeds $ checkSignatory # pconstant x # ctx) signatories
+        fails $ checkSignatory # pconstant "41" # ctx
+    , testCase "signatory validator with Cont" $ do
+        () <$ traverse (\x -> succeeds $ checkSignatoryCont # pconstant x # ctx) signatories
         fails $ checkSignatory # pconstant "41" # ctx
     ]
 

--- a/plutarch.cabal
+++ b/plutarch.cabal
@@ -177,6 +177,7 @@ test-suite examples
     , tasty
     , tasty-hunit
     , text
+    , transformers
 
   --, shrinker
   if flag(development)


### PR DESCRIPTION
An example of proper monadic do, where the monad is Cont.