### PR TITLE
Add tests for data deconstruction

### DIFF
--- a/plutarch-benchmark/bench/Main.hs
+++ b/plutarch-benchmark/bench/Main.hs
@@ -1,11 +1,19 @@
+{-# LANGUAGE QualifiedDo #-}
+
 module Main (main) where
 
 import Data.ByteString (ByteString)
+import Plutarch.Api.V1
 import Plutarch.Benchmark (NamedBenchmark, bench, bench', benchGroup, benchMain)
 import Plutarch.Bool
 import Plutarch.Builtin
 import qualified Plutarch.List as List
+import qualified Plutarch.Monadic as P
 import Plutarch.Prelude
+import Plutus.V1.Ledger.Address (Address (Address))
+import Plutus.V1.Ledger.Api (toData)
+import Plutus.V1.Ledger.Contexts (ScriptPurpose (Minting, Spending), TxOutRef (TxOutRef))
+import Plutus.V1.Ledger.Credential (Credential (PubKeyCredential))
 
 main :: IO ()
 main = do
@@ -18,6 +26,7 @@ benchmarks =
     [ benchGroup "int" integerBench
     , benchGroup "bool" boolBench
     , benchGroup "builtin:intlist" intListBench
+    , benchGroup "deconstruction:data" deconstrBench
     ]
 
 integerBench :: [[NamedBenchmark]]
@@ -130,3 +139,83 @@ intListBench =
           , bench' $ (plam (+) :: Term _ (PInteger :--> PInteger :--> PInteger))
           ]
       ]
+
+{- | For comparing typed and untyped data deconstruction approaches.
+
+We ideally want the typed and raw versions to have as little deviation as possible.
+-}
+deconstrBench :: [[NamedBenchmark]]
+deconstrBench =
+  [ benchGroup
+      "matching"
+      [ benchGroup
+          "typed"
+          [ bench "pmatch on newtype" $ P.do
+              PAddress addrFields <- pmatch $ pconstant $ Address (PubKeyCredential "ab") Nothing
+              addrFields
+          , bench "pmatch on sum type, ignoring fields" $ P.do
+              PMinting _ <- pmatch $ pconstant $ Minting ""
+              pconstant ()
+          , bench "pmatch on sum type, partial match" $ P.do
+              PMinting hs <- pmatch $ pconstant $ Minting ""
+              hs
+          , bench "pmatch on sum type, full usage, ignoring fields" $ P.do
+              purp <- pmatch $ pconstant $ Spending (TxOutRef "ab" 0)
+              case purp of
+                PMinting _ -> phexByteStr "01"
+                PSpending _ -> phexByteStr "02"
+                PRewarding _ -> phexByteStr "03"
+                PCertifying _ -> phexByteStr "04"
+          , bench "pmatch on sum type, full usage, evaluating fields" $ P.do
+              purp <- pmatch $ pconstant $ Spending (TxOutRef "ab" 0)
+              case purp of
+                PMinting f -> plet f $ const $ phexByteStr "01"
+                PSpending f -> plet f $ const $ phexByteStr "02"
+                PRewarding f -> plet f $ const $ phexByteStr "03"
+                PCertifying f -> plet f $ const $ phexByteStr "04"
+          ]
+      , benchGroup
+          "raw"
+          [ bench "pasConstr on newtype" $
+              psndBuiltin #$ pasConstr #$ pconstant $ toData $ Address (PubKeyCredential "ab") Nothing
+          , bench "pasConstr on sum type, ignoring fields" $
+              pif
+                ((pfstBuiltin #$ pasConstr #$ pconstant $ toData $ Minting "") #== 0)
+                (pconstant ())
+                perror
+          , bench "pmatch on sum type, partial match" $
+              plet (pasConstr #$ pconstant $ toData $ Minting "") $ \d ->
+                pif
+                  (pfstBuiltin # d #== 0)
+                  (psndBuiltin # d)
+                  perror
+          , bench "pmatch on sum type, full usage, ignoring fields" $ P.do
+              d <- plet $ pasConstr #$ pconstant $ toData $ Spending (TxOutRef "ab" 0)
+              constr <- plet $ pfstBuiltin # d
+              pif
+                (constr #== 0)
+                (phexByteStr "01")
+                $ pif
+                  (constr #== 1)
+                  (phexByteStr "02")
+                  $ pif
+                    (constr #== 2)
+                    (phexByteStr "03")
+                    $ phexByteStr "04"
+          , bench "pmatch on sum type, full usage, evaluating fields" $ P.do
+              d <- plet $ pasConstr #$ pconstant $ toData $ Spending (TxOutRef "ab" 0)
+              constr <- plet $ pfstBuiltin # d
+              fields <- plet $ psndBuiltin # d
+              pif
+                (constr #== 0)
+                (plet fields $ const $ phexByteStr "01")
+                $ pif
+                  (constr #== 1)
+                  (plet fields $ const $ phexByteStr "02")
+                  $ pif
+                    (constr #== 2)
+                    (plet fields $ const $ phexByteStr "03")
+                    $ plet fields $ const $ phexByteStr "04"
+          ]
+      ]
+  ]

--- a/plutarch-benchmark/bench/Main.hs
+++ b/plutarch-benchmark/bench/Main.hs
@@ -273,17 +273,17 @@ deconstrBench =
                       ( \x -> P.do
                           d <- plet $ pasConstr # x
                           constr <- plet $ pfstBuiltin # d
-                          fields <- plet $ psndBuiltin # d
+                          _ <- plet $ psndBuiltin # d
                           pif
                             (constr #== 0)
-                            (plet fields $ const $ phexByteStr "01")
+                            (phexByteStr "01")
                             $ pif
                               (constr #== 1)
-                              (plet fields $ const $ phexByteStr "02")
+                              (phexByteStr "02")
                               $ pif
                                 (constr #== 2)
-                                (plet fields $ const $ phexByteStr "03")
-                                $ plet fields $ const $ phexByteStr "04"
+                                (phexByteStr "03")
+                                $ phexByteStr "04"
                       )
                       #$ pconstant
                       $ toData spending

--- a/plutarch-benchmark/bench/Main.hs
+++ b/plutarch-benchmark/bench/Main.hs
@@ -26,7 +26,7 @@ benchmarks =
     [ benchGroup "int" integerBench
     , benchGroup "bool" boolBench
     , benchGroup "builtin:intlist" intListBench
-    , benchGroup "deconstruction:data" deconstrBench
+    , benchGroup "data" dataBench
     ]
 
 integerBench :: [[NamedBenchmark]]
@@ -139,6 +139,30 @@ intListBench =
           , bench' $ (plam (+) :: Term _ (PInteger :--> PInteger :--> PInteger))
           ]
       ]
+
+dataBench :: [[NamedBenchmark]]
+dataBench =
+  [ benchGroup "deconstruction" deconstrBench
+  , benchGroup
+      "pmatch-pfield"
+      -- These two should ideally have the exact same efficiency.
+      [ benchGroup
+          "pmatch"
+          [ bench "newtype" $ P.do
+              let addr = pconstant $ Address (PubKeyCredential "ab") Nothing
+              PAddress addrFields <- pmatch addr
+              y <- pletFields @'["credential", "stakingCredential"] addrFields
+              ppairDataBuiltin # hrecField @"credential" y # hrecField @"stakingCredential" y
+          ]
+      , benchGroup
+          "pfield"
+          [ bench "newtype" $ P.do
+              let addr = pconstant $ Address (PubKeyCredential "ab") Nothing
+              y <- pletFields @'["credential", "stakingCredential"] addr
+              ppairDataBuiltin # hrecField @"credential" y # hrecField @"stakingCredential" y
+          ]
+      ]
+  ]
 
 {- | For comparing typed and untyped data deconstruction approaches.
 

--- a/plutarch-benchmark/bench/Main.hs
+++ b/plutarch-benchmark/bench/Main.hs
@@ -162,6 +162,23 @@ dataBench =
               ppairDataBuiltin # hrecField @"credential" y # hrecField @"stakingCredential" y
           ]
       ]
+  , benchGroup
+      "pfield-pletFields"
+      -- These two should ideally have the exact same efficiency.
+      [ benchGroup
+          "pfield"
+          [ bench "single" $ P.do
+              let addr = pconstant $ Address (PubKeyCredential "ab") Nothing
+              pfromData $ pfield @"credential" # addr
+          ]
+      , benchGroup
+          "pletFields"
+          [ bench "single" $ P.do
+              let addr = pconstant $ Address (PubKeyCredential "ab") Nothing
+              y <- pletFields @'["credential"] addr
+              pfromData $ hrecField @"credential" y
+          ]
+      ]
   ]
 
 {- | For comparing typed and untyped data deconstruction approaches.

--- a/plutarch-benchmark/bench/Main.hs
+++ b/plutarch-benchmark/bench/Main.hs
@@ -263,6 +263,20 @@ deconstrBench =
                 ]
             ]
   , benchGroup
+      "fields"
+      $ let addr = Address (ScriptCredential "ab") Nothing
+         in [ benchGroup
+                "typed"
+                [ bench "extract-single" $
+                    pfield @"credential" # pconstant addr
+                ]
+            , benchGroup
+                "raw"
+                [ bench "extract-single" $
+                    phead #$ psndBuiltin #$ pasConstr # pconstant (toData addr)
+                ]
+            ]
+  , benchGroup
       "combined"
       $ let addr = Address (ScriptCredential "ab") Nothing
          in [ benchGroup

--- a/plutarch-benchmark/bench/Main.hs
+++ b/plutarch-benchmark/bench/Main.hs
@@ -290,8 +290,7 @@ deconstrBench =
                 , bench "sumtype(exhaustive)(ignore-fields)" $
                     plam
                       ( \x -> P.do
-                          d <- plet $ pasConstr # x
-                          constr <- plet $ pfstBuiltin # d
+                          constr <- plet $ pfstBuiltin #$ pasConstr # x
                           pif
                             (constr #== 0)
                             (phexByteStr "01")

--- a/plutarch-benchmark/plutarch-benchmark.cabal
+++ b/plutarch-benchmark/plutarch-benchmark.cabal
@@ -101,6 +101,7 @@ benchmark benchmark
     , base
     , plutarch
     , plutarch-benchmark
+    , plutus-ledger-api
     , bytestring
 
 executable benchmark-diff


### PR DESCRIPTION
This should help us track our progress on matching the performance of `PDataRepr` based machinery to raw untyped builtin functions.

Relevant: https://github.com/Plutonomicon/plutarch/issues/214