### PR TITLE
Explicitly set the locale encoding to utf8

### DIFF
--- a/examples/Main.hs
+++ b/examples/Main.hs
@@ -11,6 +11,7 @@ import qualified Data.ByteString as BS
 import Data.Maybe (fromJust)
 import qualified Examples.List as List
 import Examples.Tracing (traceTests)
+import GHC.IO.Encoding (setLocaleEncoding, utf8)
 import Plutarch (POpaque, popaque, printTerm)
 import Plutarch.Api.V1 (PScriptPurpose (PMinting))
 import Plutarch.Bool (pand, por)
@@ -34,7 +35,9 @@ import Utils
 import Data.Text (Text)
 
 main :: IO ()
-main = defaultMain $ testGroup "all tests" [standardTests] -- , shrinkTests ]
+main = do
+  setLocaleEncoding utf8
+  defaultMain $ testGroup "all tests" [standardTests] -- , shrinkTests ]
 
 add1 :: Term s (PInteger :--> PInteger :--> PInteger)
 add1 = plam $ \x y -> x + y + 1


### PR DESCRIPTION
Fixed the issue with

    examples: <stdout>: commitBuffer: invalid argument (invalid character)

with `setLocaleEncoding utf8` as suggested by Maciej Bendkowski.