### PR TITLE
Deconstr bench enhance

### DIFF
--- a/plutarch-benchmark/bench/Main.hs
+++ b/plutarch-benchmark/bench/Main.hs
@@ -4,6 +4,7 @@ module Main (main) where
 
 import Control.Monad.Trans.Cont (cont, runCont)
 import Data.ByteString (ByteString)
+import Plutarch (ClosedTerm)
 import Plutarch.Api.V1
 import Plutarch.Benchmark (NamedBenchmark, bench, bench', benchGroup, benchMain)
 import Plutarch.Bool
@@ -12,9 +13,12 @@ import qualified Plutarch.List as List
 import qualified Plutarch.Monadic as P
 import Plutarch.Prelude
 import Plutus.V1.Ledger.Address (Address (Address))
-import Plutus.V1.Ledger.Api (toData)
-import Plutus.V1.Ledger.Contexts (ScriptPurpose (Minting, Spending), TxOutRef (TxOutRef))
-import Plutus.V1.Ledger.Credential (Credential (PubKeyCredential, ScriptCredential))
+import Plutus.V1.Ledger.Api (DCert (DCertGenesis), toData)
+import Plutus.V1.Ledger.Contexts (ScriptPurpose (Certifying, Minting, Rewarding, Spending), TxOutRef (TxOutRef))
+import Plutus.V1.Ledger.Credential (
+  Credential (PubKeyCredential, ScriptCredential),
+  StakingCredential (StakingPtr),
+ )
 
 main :: IO ()
 main = do
@@ -191,179 +195,193 @@ deconstrBench :: [[NamedBenchmark]]
 deconstrBench =
   [ benchGroup
       "matching"
-      $ let addr = Address (PubKeyCredential "ab") Nothing
-            minting = Minting ""
-            spending = Spending (TxOutRef "ab" 0)
-         in [ benchGroup
-                "typed"
-                [ bench "newtype" $
-                    plam
-                      ( \x -> P.do
-                          PAddress addrFields <- pmatch x
-                          addrFields
-                      )
-                      # pconstant addr
-                , bench "sumtype(ignore-fields)" $
-                    plam
-                      ( \x -> P.do
-                          PMinting _ <- pmatch x
-                          pconstant ()
-                      )
-                      # pconstant minting
-                , bench "sumtype(partial-match)" $
-                    plam
-                      ( \x -> P.do
-                          PMinting hs <- pmatch x
-                          hs
-                      )
-                      # pconstant minting
-                , bench "sumtype(exhaustive)" $
-                    plam
-                      ( \x -> P.do
-                          purp <- pmatch x
-                          case purp of
-                            PMinting f -> plet f $ const $ phexByteStr "01"
-                            PSpending f -> plet f $ const $ phexByteStr "02"
-                            PRewarding f -> plet f $ const $ phexByteStr "03"
-                            PCertifying f -> plet f $ const $ phexByteStr "04"
-                      )
-                      # pconstant spending
-                , bench "sumtype(exhaustive)(ignore-fields)" $
-                    plam
-                      ( \x -> P.do
-                          purp <- pmatch x
-                          case purp of
-                            PMinting _ -> phexByteStr "01"
-                            PSpending _ -> phexByteStr "02"
-                            PRewarding _ -> phexByteStr "03"
-                            PCertifying _ -> phexByteStr "04"
-                      )
-                      # pconstant spending
-                ]
-            , benchGroup
-                "raw"
-                [ bench "newtype" $
-                    plam
-                      ( \x ->
-                          psndBuiltin #$ pasConstr # x
-                      )
-                      #$ pconstant
-                      $ toData addr
-                , bench "sumtype(ignore-fields)" $
-                    plam
-                      ( \x ->
-                          pif
-                            ((pfstBuiltin #$ pasConstr # x) #== 0)
-                            (pconstant ())
-                            perror
-                      )
-                      #$ pconstant
-                      $ toData minting
-                , bench "sumtype(partial-match)" $
-                    plam
-                      ( \x ->
-                          plet (pasConstr # x) $ \d ->
-                            pif
-                              (pfstBuiltin # d #== 0)
-                              (psndBuiltin # d)
-                              perror
-                      )
-                      #$ pconstant
-                      $ toData minting
-                , bench "sumtype(exhaustive)" $
-                    plam
-                      ( \x -> P.do
-                          d <- plet $ pasConstr # x
-                          constr <- plet $ pfstBuiltin # d
-                          _ <- plet $ psndBuiltin # d
-                          pif
-                            (constr #== 0)
-                            (phexByteStr "01")
-                            $ pif
-                              (constr #== 1)
-                              (phexByteStr "02")
-                              $ pif
-                                (constr #== 2)
-                                (phexByteStr "03")
-                                $ phexByteStr "04"
-                      )
-                      #$ pconstant
-                      $ toData spending
-                , bench "sumtype(exhaustive)(ignore-fields)" $
-                    plam
-                      ( \x -> P.do
-                          constr <- plet $ pfstBuiltin #$ pasConstr # x
-                          pif
-                            (constr #== 0)
-                            (phexByteStr "01")
-                            $ pif
-                              (constr #== 1)
-                              (phexByteStr "02")
-                              $ pif
-                                (constr #== 2)
-                                (phexByteStr "03")
-                                $ phexByteStr "04"
-                      )
-                      #$ pconstant
-                      $ toData spending
-                ]
+      $ [ benchGroup
+            "typed"
+            [ bench "newtype" $
+                plam
+                  ( \x -> P.do
+                      PAddress addrFields <- pmatch x
+                      addrFields
+                  )
+                  # pconstant addrPC
+            , bench "sumtype(ignore-fields)" $
+                plam
+                  ( \x -> P.do
+                      PMinting _ <- pmatch x
+                      pconstant ()
+                  )
+                  # pconstant minting
+            , bench "sumtype(partial-match)" $
+                plam
+                  ( \x -> P.do
+                      PMinting hs <- pmatch x
+                      hs
+                  )
+                  # pconstant minting
+            , benchGroup "sumtype(exhaustive)" $
+                benchPurpose $
+                  plam
+                    ( \x -> P.do
+                        purp <- pmatch x
+                        case purp of
+                          PMinting f -> plet f $ const $ phexByteStr "01"
+                          PSpending f -> plet f $ const $ phexByteStr "02"
+                          PRewarding f -> plet f $ const $ phexByteStr "03"
+                          PCertifying f -> plet f $ const $ phexByteStr "04"
+                    )
+            , benchGroup "sumtype(exhaustive)(ignore-fields)" $ benchPurpose $
+                plam
+                  ( \x -> P.do
+                      purp <- pmatch x
+                      case purp of
+                        PMinting _ -> phexByteStr "01"
+                        PSpending _ -> phexByteStr "02"
+                        PRewarding _ -> phexByteStr "03"
+                        PCertifying _ -> phexByteStr "04"
+                  )
             ]
+        , benchGroup
+            "raw"
+            [ bench "newtype" $
+                plam
+                  ( \x ->
+                      psndBuiltin #$ pasConstr # x
+                  )
+                  #$ pconstant
+                  $ toData addrPC
+            , bench "sumtype(ignore-fields)" $
+                plam
+                  ( \x ->
+                      pif
+                        ((pfstBuiltin #$ pasConstr # x) #== 0)
+                        (pconstant ())
+                        perror
+                  )
+                  #$ pconstant
+                  $ toData minting
+            , bench "sumtype(partial-match)" $
+                plam
+                  ( \x ->
+                      plet (pasConstr # x) $ \d ->
+                        pif
+                          (pfstBuiltin # d #== 0)
+                          (psndBuiltin # d)
+                          perror
+                  )
+                  #$ pconstant
+                  $ toData minting
+            , benchGroup "sumtype(exhaustive)" $ benchPurpose' $
+                plam
+                  ( \x -> P.do
+                      d <- plet $ pasConstr # x
+                      constr <- plet $ pfstBuiltin # d
+                      _ <- plet $ psndBuiltin # d
+                      pif
+                        (constr #== 1)
+                        (phexByteStr "02")
+                        $ pif
+                          (constr #== 2)
+                          (phexByteStr "03")
+                          $ pif
+                            (constr #== 3)
+                            (phexByteStr "04")
+                            $ phexByteStr "01"
+                  )
+            , benchGroup "sumtype(exhaustive)(ignore-fields)" $ benchPurpose' $
+                plam
+                  ( \x -> P.do
+                      constr <- plet $ pfstBuiltin #$ pasConstr # x
+                      pif
+                        (constr #== 1)
+                        (phexByteStr "02")
+                        $ pif
+                          (constr #== 2)
+                          (phexByteStr "03")
+                          $ pif
+                            (constr #== 3)
+                            (phexByteStr "04")
+                            $ phexByteStr "01"
+                  )
+            ]
+        ]
   , benchGroup
       "fields"
-      $ let addr = Address (ScriptCredential "ab") Nothing
-         in [ benchGroup
-                "typed"
-                [ bench "extract-single" $
-                    plam
-                      ( \x ->
-                          pfield @"credential" # x
-                      )
-                      # pconstant addr
-                ]
-            , benchGroup
-                "raw"
-                [ bench "extract-single" $
-                    plam
-                      ( \x ->
-                          phead #$ psndBuiltin #$ pasConstr # x
-                      )
-                      #$ pconstant
-                      $ toData addr
-                ]
+      $ [ benchGroup
+            "typed"
+            [ bench "extract-single" $
+                plam
+                  ( \x ->
+                      pfield @"credential" # x
+                  )
+                  # pconstant addrSC
             ]
+        , benchGroup
+            "raw"
+            [ bench "extract-single" $
+                plam
+                  ( \x ->
+                      phead #$ psndBuiltin #$ pasConstr # x
+                  )
+                  #$ pconstant
+                  $ toData addrSC
+            ]
+        ]
   , benchGroup
       "combined"
-      $ let addr = Address (ScriptCredential "ab") Nothing
-         in [ benchGroup
-                "typed"
-                [ bench "toValidatorHash" $
-                    plam
-                      ( \x -> P.do
-                          cred <- pmatch . pfromData $ pfield @"credential" # x
-                          case cred of
-                            PPubKeyCredential _ -> pcon PNothing
-                            PScriptCredential credFields -> pcon . PJust $ pto $ pfromData $ pfield @"_0" # credFields
-                      )
-                      # pconstant addr
-                ]
-            , benchGroup
-                "raw"
-                [ bench "toValidatorHash" $
-                    plam
-                      ( \x ->
-                          P.do
-                            let cred = phead #$ psndBuiltin #$ pasConstr # x
-                            deconstrCred <- plet $ pasConstr # cred
-                            pif
-                              (pfstBuiltin # deconstrCred #== 0)
-                              (pcon PNothing)
-                              $ pcon . PJust $ pasByteStr #$ phead #$ psndBuiltin # deconstrCred
-                      )
-                      #$ pconstant
-                      $ toData addr
-                ]
-            ]
+      [ benchGroup
+          "typed"
+          [ bench "toValidatorHash" $
+              plam
+                ( \x -> P.do
+                    cred <- pmatch . pfromData $ pfield @"credential" # x
+                    case cred of
+                      PPubKeyCredential _ -> pcon PNothing
+                      PScriptCredential credFields -> pcon . PJust $ pto $ pfromData $ pfield @"_0" # credFields
+                )
+                # pconstant addrSC
+          ]
+      , benchGroup
+          "raw"
+          [ bench "toValidatorHash" $
+              plam
+                ( \x ->
+                    P.do
+                      let cred = phead #$ psndBuiltin #$ pasConstr # x
+                      deconstrCred <- plet $ pasConstr # cred
+                      pif
+                        (pfstBuiltin # deconstrCred #== 0)
+                        (pcon PNothing)
+                        $ pcon . PJust $ pasByteStr #$ phead #$ psndBuiltin # deconstrCred
+                )
+                #$ pconstant
+                $ toData addrSC
+          ]
+      ]
   ]
+  where
+    addrSC = Address (ScriptCredential "ab") Nothing
+    addrPC = Address (PubKeyCredential "ab") Nothing
+    minting = Minting ""
+    spending = Spending (TxOutRef "ab" 0)
+    rewarding = Rewarding (StakingPtr 42 0 7)
+    certifying = Certifying DCertGenesis
+    -- | Bench given function feeding in all 4 types of script purpose (typed).
+    benchPurpose :: ClosedTerm (PScriptPurpose :--> PByteString) -> [[NamedBenchmark]]
+    benchPurpose f =
+      [ bench "minting" $ f # pconstant minting
+      , bench "spending" $ f # pconstant spending
+      , bench "rewarding" $ f # pconstant rewarding
+      , bench "certifying" $ f # pconstant certifying
+      ]
+
+    -- | Bench given function feeding in all 4 types of script purpose (untyped).
+    benchPurpose' :: ClosedTerm (PData :--> PByteString) -> [[NamedBenchmark]]
+    benchPurpose' f =
+      [ bench "minting" $ f #$ pconstant $ toData minting
+      , bench "spending" $ f #$ pconstant $ toData spending
+      , bench "rewarding" $ f #$ pconstant $ toData rewarding
+      , bench "certifying" $ f #$ pconstant $ toData certifying
+      ]
 
 -- | Nested lambda, vs do-syntax vs cont monad.
 syntaxBench :: [[NamedBenchmark]]

--- a/plutarch-benchmark/bench/Main.hs
+++ b/plutarch-benchmark/bench/Main.hs
@@ -229,16 +229,17 @@ deconstrBench =
                           PRewarding f -> plet f $ const $ phexByteStr "03"
                           PCertifying f -> plet f $ const $ phexByteStr "04"
                     )
-            , benchGroup "sumtype(exhaustive)(ignore-fields)" $ benchPurpose $
-                plam
-                  ( \x -> P.do
-                      purp <- pmatch x
-                      case purp of
-                        PMinting _ -> phexByteStr "01"
-                        PSpending _ -> phexByteStr "02"
-                        PRewarding _ -> phexByteStr "03"
-                        PCertifying _ -> phexByteStr "04"
-                  )
+            , benchGroup "sumtype(exhaustive)(ignore-fields)" $
+                benchPurpose $
+                  plam
+                    ( \x -> P.do
+                        purp <- pmatch x
+                        case purp of
+                          PMinting _ -> phexByteStr "01"
+                          PSpending _ -> phexByteStr "02"
+                          PRewarding _ -> phexByteStr "03"
+                          PCertifying _ -> phexByteStr "04"
+                    )
             ]
         , benchGroup
             "raw"
@@ -270,38 +271,40 @@ deconstrBench =
                   )
                   #$ pconstant
                   $ toData minting
-            , benchGroup "sumtype(exhaustive)" $ benchPurpose' $
-                plam
-                  ( \x -> P.do
-                      d <- plet $ pasConstr # x
-                      constr <- plet $ pfstBuiltin # d
-                      _ <- plet $ psndBuiltin # d
-                      pif
-                        (constr #== 1)
-                        (phexByteStr "02")
-                        $ pif
-                          (constr #== 2)
-                          (phexByteStr "03")
+            , benchGroup "sumtype(exhaustive)" $
+                benchPurpose' $
+                  plam
+                    ( \x -> P.do
+                        d <- plet $ pasConstr # x
+                        constr <- plet $ pfstBuiltin # d
+                        _ <- plet $ psndBuiltin # d
+                        pif
+                          (constr #== 1)
+                          (phexByteStr "02")
                           $ pif
-                            (constr #== 3)
-                            (phexByteStr "04")
-                            $ phexByteStr "01"
-                  )
-            , benchGroup "sumtype(exhaustive)(ignore-fields)" $ benchPurpose' $
-                plam
-                  ( \x -> P.do
-                      constr <- plet $ pfstBuiltin #$ pasConstr # x
-                      pif
-                        (constr #== 1)
-                        (phexByteStr "02")
-                        $ pif
-                          (constr #== 2)
-                          (phexByteStr "03")
+                            (constr #== 2)
+                            (phexByteStr "03")
+                            $ pif
+                              (constr #== 3)
+                              (phexByteStr "04")
+                              $ phexByteStr "01"
+                    )
+            , benchGroup "sumtype(exhaustive)(ignore-fields)" $
+                benchPurpose' $
+                  plam
+                    ( \x -> P.do
+                        constr <- plet $ pfstBuiltin #$ pasConstr # x
+                        pif
+                          (constr #== 1)
+                          (phexByteStr "02")
                           $ pif
-                            (constr #== 3)
-                            (phexByteStr "04")
-                            $ phexByteStr "01"
-                  )
+                            (constr #== 2)
+                            (phexByteStr "03")
+                            $ pif
+                              (constr #== 3)
+                              (phexByteStr "04")
+                              $ phexByteStr "01"
+                    )
             ]
         ]
   , benchGroup
@@ -365,7 +368,7 @@ deconstrBench =
     spending = Spending (TxOutRef "ab" 0)
     rewarding = Rewarding (StakingPtr 42 0 7)
     certifying = Certifying DCertGenesis
-    -- | Bench given function feeding in all 4 types of script purpose (typed).
+    -- Bench given function feeding in all 4 types of script purpose (typed).
     benchPurpose :: ClosedTerm (PScriptPurpose :--> PByteString) -> [[NamedBenchmark]]
     benchPurpose f =
       [ bench "minting" $ f # pconstant minting
@@ -374,7 +377,7 @@ deconstrBench =
       , bench "certifying" $ f # pconstant certifying
       ]
 
-    -- | Bench given function feeding in all 4 types of script purpose (untyped).
+    -- Bench given function feeding in all 4 types of script purpose (untyped).
     benchPurpose' :: ClosedTerm (PData :--> PByteString) -> [[NamedBenchmark]]
     benchPurpose' f =
       [ bench "minting" $ f #$ pconstant $ toData minting


### PR DESCRIPTION
Well, that diff rendering is terrible - so here's all the changes-
* Move the `let` bindings being used in each `benchGroup` out to a `where` block within `deconstrBench`. Less nesting, better looking. Doesn't change anything anyway.
* Make the `sumtype(exhaustive)*` bench apply *all* `ScriptPurpose` constructors one by one to get a significantly better idea of performance.

  The reason the raw untyped one was performing *worse* than the typed one previously was because a `Spending` script purpose just happened to be the happy path for the typed one - but not the untyped one.