### PR TITLE
Fix another typo

### DIFF
--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -773,7 +773,7 @@ This is similar to the `Integral` typeclass. However, it only has the following 
 * `pdiv` - similar to `div`
 * `pmod` - similar to `mod`
 * `pquot` - similar to `quot`
-* `prem` - similar to `prem`
+* `prem` - similar to `rem`
 
 Using these functions, you can do division/modulus etc on Plutarch level values-
 ```hs


### PR DESCRIPTION
'prem''s equivalent in Plutus is 'rem', not also 'prem'.