### PR TITLE
Add `pconstantData` - a direct way of building `Data` encoded constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@
 
   Started by: [#226](https://github.com/Plutonomicon/plutarch/pull/226)
 
+- Add `pconstantData` - an efficient way of building data encoded constants directly.
+
+  This is semantically equivalent to `pdata . pconstant` but does not do any extra builtin function call.
+
+  Module: `Plutarch.Builtin`
+
+  Added by: [#242](https://github.com/Plutonomicon/plutarch/pull/242)
+
 # 1.1.0
 
 - General repository changes.

--- a/Plutarch/Api/V1/Value.hs
+++ b/Plutarch/Api/V1/Value.hs
@@ -38,9 +38,7 @@ deriving via
 
 newtype PValue (s :: S) = PValue (Term s (PMap PCurrencySymbol (PMap PTokenName PInteger)))
   deriving
-    ( PlutusType
-    , PIsData
-    )
+    (PlutusType, PIsData)
     via (DerivePNewtype PValue (PMap PCurrencySymbol (PMap PTokenName PInteger)))
 
 instance PUnsafeLiftDecl PValue where type PLifted PValue = Plutus.Value

--- a/Plutarch/Builtin.hs
+++ b/Plutarch/Builtin.hs
@@ -306,5 +306,5 @@ pconstrBuiltin = punsafeBuiltin $ PLC.MkCons
 Example:
 > pconstantData @PInteger 42
 -}
-pconstantData :: forall p s. (ToData (PLifted p)) => PLifted p -> Term s (PAsData p)
+pconstantData :: forall p h s. (ToData h, PLifted p ~ h, PConstanted h ~ p) => h -> Term s (PAsData p)
 pconstantData x = punsafeCoerce $ pconstant $ PlutusTx.toData x

--- a/Plutarch/Prelude.hs
+++ b/Plutarch/Prelude.hs
@@ -123,6 +123,7 @@ module Plutarch.Prelude (
 
   -- * Converstion between Plutarch terms and Haskell types
   pconstant,
+  pconstantData,
   plift,
   PConstant,
   PLift,

--- a/examples/Examples/Lift.hs
+++ b/examples/Examples/Lift.hs
@@ -1,0 +1,37 @@
+module Examples.Lift (tests) where
+
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (testCase, (@?=), Assertion)
+
+import Utils
+
+import Plutarch.Prelude
+import Plutarch (printTerm)
+import Plutarch.Lift (PLifted)
+import Plutus.V1.Ledger.Api
+import qualified PlutusTx
+
+testPConstantDataSan :: forall p. (HasTester, PIsData p, PLift p, PlutusTx.ToData (PLifted p)) => PLifted p -> Assertion
+testPConstantDataSan x = pconstantData @p x `equal` pdata (pconstant @p x)
+
+tests :: HasTester => TestTree
+tests = testGroup "pconstant/plift tests" [pconstantDataTests]
+
+pconstantDataTests :: HasTester => TestTree
+pconstantDataTests =
+  testGroup
+    "pconstantData"
+    [ testCase "pconstantData ≡ pdata . pconstant" $ do
+        testPConstantDataSan ()
+        testPConstantDataSan False
+        testPConstantDataSan @PInteger 42
+        testPConstantDataSan $ PubKeyHash "04"
+        testPConstantDataSan $ Minting ""
+        testPConstantDataSan $ TxOutRef "41" 12
+    , testCase "pconstantData compiled output" $ do
+        printTerm (pconstantData @PInteger 42) @?= "(program 1.0.0 #182a)"
+        printTerm (pconstantData True) @?= "(program 1.0.0 #d87a80)"
+        printTerm (pconstantData $ PubKeyHash "04") @?= "(program 1.0.0 #423034)"
+        printTerm (pconstantData $ Minting "") @?= "(program 1.0.0 #d8799f40ff)"
+        printTerm (pconstantData $ TxOutRef "41" 12) @?= "(program 1.0.0 #d8799fd8799f4141ff0cff)"
+    ]

--- a/examples/Examples/Lift.hs
+++ b/examples/Examples/Lift.hs
@@ -1,13 +1,13 @@
 module Examples.Lift (tests) where
 
 import Test.Tasty (TestTree, testGroup)
-import Test.Tasty.HUnit (testCase, (@?=), Assertion)
+import Test.Tasty.HUnit (Assertion, testCase, (@?=))
 
 import Utils
 
-import Plutarch.Prelude
 import Plutarch (printTerm)
 import Plutarch.Lift (PLifted)
+import Plutarch.Prelude
 import Plutus.V1.Ledger.Api
 import qualified PlutusTx
 
@@ -22,7 +22,6 @@ pconstantDataTests =
   testGroup
     "pconstantData"
     [ testCase "pconstantData ≡ pdata . pconstant" $ do
-        testPConstantDataSan ()
         testPConstantDataSan False
         testPConstantDataSan @PInteger 42
         testPConstantDataSan $ PubKeyHash "04"

--- a/examples/Examples/PIsData.hs
+++ b/examples/Examples/PIsData.hs
@@ -7,12 +7,9 @@ import Test.Tasty.HUnit
 
 import Utils
 
-import Plutarch
-import Plutarch.Bool
-import Plutarch.Builtin
-import Plutarch.Integer
-import Plutarch.Lift
-import Plutarch.Unsafe (punsafeCoerce)
+import Plutarch.Builtin (pforgetData)
+import Plutarch.Lift (PLifted)
+import Plutarch.Prelude
 
 import qualified PlutusTx
 
@@ -41,7 +38,7 @@ testPFromDataCompat ::
   PLifted p ->
   Assertion
 testPFromDataCompat x =
-  plift (pfromData $ constPAsData @p x)
+  plift (pfromData $ pconstantData @p x)
     @?= x
 
 testPDataCompat ::
@@ -57,9 +54,6 @@ testPDataCompat ::
 testPDataCompat x =
   PlutusTx.fromData @(PLifted p) (plift $ pforgetData $ pdata $ pconstant @p x)
     @?= Just x
-
-constPAsData :: forall p s. (PlutusTx.ToData (PLifted p)) => PLifted p -> Term s (PAsData p)
-constPAsData x = punsafeCoerce $ pconstant @PData $ PlutusTx.toData x
 
 --------------------------------------------------------------------------------
 -- TODO: These shoutld probably be property tests instead...

--- a/examples/Main.hs
+++ b/examples/Main.hs
@@ -26,11 +26,11 @@ import qualified PlutusTx
 import qualified Examples.Api as Api
 import qualified Examples.Field as Field
 import qualified Examples.LetRec as LetRec
+import qualified Examples.Lift as Lift
 import qualified Examples.PIsData as PIsData
 import qualified Examples.PlutusType as PlutusType
 import qualified Examples.Rationals as Rationals
 import qualified Examples.Recursion as Recursion
-import qualified Examples.Lift as Lift
 import Utils
 
 import Data.Text (Text)

--- a/examples/Main.hs
+++ b/examples/Main.hs
@@ -30,6 +30,7 @@ import qualified Examples.PIsData as PIsData
 import qualified Examples.PlutusType as PlutusType
 import qualified Examples.Rationals as Rationals
 import qualified Examples.Recursion as Recursion
+import qualified Examples.Lift as Lift
 import Utils
 
 import Data.Text (Text)
@@ -93,6 +94,7 @@ tests =
     , LetRec.tests
     , PIsData.tests
     , Field.tests
+    , Lift.tests
     ]
 
 plutarchTests :: HasTester => TestTree

--- a/plutarch.cabal
+++ b/plutarch.cabal
@@ -81,14 +81,12 @@ library
     Plutarch.Api.V1
     Plutarch.Api.V1.Address
     Plutarch.Api.V1.AssocMap
-    Plutarch.Api.V1.Bytes
     Plutarch.Api.V1.Contexts
     Plutarch.Api.V1.Crypto
     Plutarch.Api.V1.DCert
     Plutarch.Api.V1.Interval
     Plutarch.Api.V1.Maybe
     Plutarch.Api.V1.Scripts
-    Plutarch.Api.V1.Slot
     Plutarch.Api.V1.Time
     Plutarch.Api.V1.Tx
     Plutarch.Api.V1.Value

--- a/plutarch.cabal
+++ b/plutarch.cabal
@@ -81,12 +81,14 @@ library
     Plutarch.Api.V1
     Plutarch.Api.V1.Address
     Plutarch.Api.V1.AssocMap
+    Plutarch.Api.V1.Bytes
     Plutarch.Api.V1.Contexts
     Plutarch.Api.V1.Crypto
     Plutarch.Api.V1.DCert
     Plutarch.Api.V1.Interval
     Plutarch.Api.V1.Maybe
     Plutarch.Api.V1.Scripts
+    Plutarch.Api.V1.Slot
     Plutarch.Api.V1.Time
     Plutarch.Api.V1.Tx
     Plutarch.Api.V1.Value
@@ -158,6 +160,7 @@ test-suite examples
     Examples.Api
     Examples.Field
     Examples.LetRec
+    Examples.Lift
     Examples.List
     Examples.PIsData
     Examples.PlutusType


### PR DESCRIPTION
For some reason `ByteString` doesn't have a `ToData` instance so you can't build `PAsData PByteString` directly with `pconstantData`.

You can build newtypes to bytestrings though, stuff like `PAsData PCurrencySymbol`