### PR TITLE
Add `packages.${system}.haddock` attribute for combined haddock

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -602,6 +602,32 @@
                 nix --extra-experimental-features 'nix-command flakes' run .#benchmark-diff -- before.csv after.csv
               '';
             }
+          )
+          gh-pages = hci-effects.runIf (src.ref == "refs/heads/master") (
+            hci-effects.mkEffect {
+              src = self;
+              buildInputs = with pkgs; [ openssh git ];
+              secretsMap = {
+                "ssh" = "ssh";
+              };
+              effectScript =
+              let
+                githubHostKey = "github.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==";
+              in
+              ''
+                writeSSHKey
+                echo ${githubHostKey} >> ~/.ssh/known_hosts
+                export GIT_AUTHOR_NAME="Hercules-CI Effects"
+                export GIT_COMMITTER_NAME="Hercules-CI Effects"
+                export EMAIL="github@croughan.sh"
+                cp -r --no-preserve=mode ${self.packages.x86_64-linux.haddock}/share/doc ./gh-pages && cd gh-pages
+                git init -b gh-pages
+                git remote add origin git@github.com:Plutonomicon/plutarch.git
+                git add .
+                git commit -m "Deploy to gh-pages"
+                git push -f origin gh-pages:gh-pages
+              '';
+            }
           );
         };
 

--- a/flake.nix
+++ b/flake.nix
@@ -489,14 +489,10 @@
             ghc = pkgs.haskell-nix.compiler.${ghcVersion};
             inherit (sphinxcontrib-haddock) sphinxcontrib-haddock;
           };
-          # FIXME: > Couldn't get the project and version from the html
-          # hspkgs = builtins.map (x: x.library) (
-          #   builtins.filter (x: x ? library) (
-          #     builtins.map (x: x.components) (
-          #       builtins.filter (x: x ? components) (
-          #         builtins.attrValues self.project.${system}.hsPkgs
-          #       )
-          #     )
+          # If you use this, filter out pretty-show, it doesn't work if not.
+          # hspkgs = builtins.map (x: x.components.library) (
+          #   builtins.filter (x: x ? components && x.components ? library) (
+          #     builtins.attrValues self.project.${system}.hsPkgs
           #   )
           # );
           hspkgs = builtins.map (x: self.project.${system}.hsPkgs.${x}.components.library) [

--- a/flake.nix
+++ b/flake.nix
@@ -602,7 +602,7 @@
                 nix --extra-experimental-features 'nix-command flakes' run .#benchmark-diff -- before.csv after.csv
               '';
             }
-          )
+          );
           gh-pages = hci-effects.runIf (src.ref == "refs/heads/master") (
             hci-effects.mkEffect {
               src = self;
@@ -611,22 +611,22 @@
                 "ssh" = "ssh";
               };
               effectScript =
-              let
-                githubHostKey = "github.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==";
-              in
-              ''
-                writeSSHKey
-                echo ${githubHostKey} >> ~/.ssh/known_hosts
-                export GIT_AUTHOR_NAME="Hercules-CI Effects"
-                export GIT_COMMITTER_NAME="Hercules-CI Effects"
-                export EMAIL="github@croughan.sh"
-                cp -r --no-preserve=mode ${self.packages.x86_64-linux.haddock}/share/doc ./gh-pages && cd gh-pages
-                git init -b gh-pages
-                git remote add origin git@github.com:Plutonomicon/plutarch.git
-                git add .
-                git commit -m "Deploy to gh-pages"
-                git push -f origin gh-pages:gh-pages
-              '';
+                let
+                  githubHostKey = "github.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==";
+                in
+                ''
+                  writeSSHKey
+                  echo ${githubHostKey} >> ~/.ssh/known_hosts
+                  export GIT_AUTHOR_NAME="Hercules-CI Effects"
+                  export GIT_COMMITTER_NAME="Hercules-CI Effects"
+                  export EMAIL="github@croughan.sh"
+                  cp -r --no-preserve=mode ${self.packages.x86_64-linux.haddock}/share/doc ./gh-pages && cd gh-pages
+                  git init -b gh-pages
+                  git remote add origin git@github.com:Plutonomicon/plutarch.git
+                  git add .
+                  git commit -m "Deploy to gh-pages"
+                  git push -f origin gh-pages:gh-pages
+                '';
             }
           );
         };

--- a/flake.nix
+++ b/flake.nix
@@ -524,8 +524,6 @@
     {
       inherit extraSources cabalProjectLocal haskellModule tools;
 
-      nixpkgsDebug = perSystem nixpkgsFor;
-
       project = perSystem projectFor;
       project810 = perSystem projectFor810;
       flake = perSystem (system: (projectFor system).flake { });


### PR DESCRIPTION
Unfortunately, it seems that we can't add all packages to this,
it errs with `Couldn't get the project and version from the html`,
and I'm not sure why.

Do `nix build .#haddock` to test. This is self-contained and can be
hosted on GitHub Pages.