### PR TITLE
Make output directory of `benchMain` CSV file configurable

### DIFF
--- a/plutarch-benchmark/benchmark-diff/Main.hs
+++ b/plutarch-benchmark/benchmark-diff/Main.hs
@@ -3,21 +3,25 @@ module Main (main) where
 import Plutarch.Benchmark (decodeBenchmarks, diffBenchmarks, renderDiffTable)
 
 import qualified Data.ByteString.Lazy as BSL
-import System.Environment (getArgs)
+import Options.Applicative
 import qualified Text.PrettyPrint.Boxes as B
 
 --------------------------------------------------------------------------------
 
 main :: IO ()
-main =
-  getArgs >>= \case
-    [oldPath, newPath] -> do
-      Right old <- decodeBenchmarks <$> BSL.readFile oldPath
-      Right new <- decodeBenchmarks <$> BSL.readFile newPath
-
-      putStrLn . B.render . renderDiffTable $ diffBenchmarks old new
-    _ -> usage
-
-usage :: IO ()
-usage =
-  putStrLn "usage: benchmark-diff [old] [new]"
+main = do
+  let cmdOptions =
+        liftA2
+          (,)
+          (argument str (metavar "BEFORE"))
+          (argument str (metavar "AFTER"))
+      opts =
+        info
+          (cmdOptions <**> helper)
+          ( fullDesc
+              <> progDesc "Diff two benchmark CSVs"
+          )
+  (oldPath, newPath) <- execParser opts
+  Right old <- decodeBenchmarks <$> BSL.readFile oldPath
+  Right new <- decodeBenchmarks <$> BSL.readFile newPath
+  putStrLn . B.render . renderDiffTable $ diffBenchmarks old new

--- a/plutarch-benchmark/benchmark-diff/Main.hs
+++ b/plutarch-benchmark/benchmark-diff/Main.hs
@@ -3,7 +3,18 @@ module Main (main) where
 import Plutarch.Benchmark (decodeBenchmarks, diffBenchmarks, renderDiffTable)
 
 import qualified Data.ByteString.Lazy as BSL
-import Options.Applicative
+import Options.Applicative (
+  argument,
+  execParser,
+  fullDesc,
+  helper,
+  info,
+  liftA2,
+  metavar,
+  progDesc,
+  str,
+  (<**>),
+ )
 import qualified Text.PrettyPrint.Boxes as B
 
 --------------------------------------------------------------------------------

--- a/plutarch-benchmark/plutarch-benchmark.cabal
+++ b/plutarch-benchmark/plutarch-benchmark.cabal
@@ -73,9 +73,9 @@ library
   import:          c
   exposed-modules: Plutarch.Benchmark
   build-depends:
+    , aeson
     , base
     , boxes
-    , aeson
     , bytestring
     , cassava
     , containers
@@ -83,6 +83,7 @@ library
     , flat
     , foldl
     , mtl
+    , optparse-applicative
     , plutarch
     , plutus-core
     , plutus-ledger-api
@@ -100,10 +101,10 @@ benchmark benchmark
   main-is:        Main.hs
   build-depends:
     , base
+    , bytestring
     , plutarch
     , plutarch-benchmark
     , plutus-ledger-api
-    , bytestring
     , transformers
 
 executable benchmark-diff

--- a/plutarch-benchmark/plutarch-benchmark.cabal
+++ b/plutarch-benchmark/plutarch-benchmark.cabal
@@ -118,3 +118,4 @@ executable benchmark-diff
     , cassava
     , plutarch
     , plutarch-benchmark
+    , optparse-applicative

--- a/plutarch-benchmark/plutarch-benchmark.cabal
+++ b/plutarch-benchmark/plutarch-benchmark.cabal
@@ -116,6 +116,6 @@ executable benchmark-diff
     , boxes
     , bytestring
     , cassava
+    , optparse-applicative
     , plutarch
     , plutarch-benchmark
-    , optparse-applicative

--- a/plutarch-benchmark/src/Plutarch/Benchmark.hs
+++ b/plutarch-benchmark/src/Plutarch/Benchmark.hs
@@ -29,7 +29,22 @@ import Data.Coerce (coerce)
 import qualified Data.Map.Strict as Map
 import Data.Vector (Vector, (!))
 import qualified Data.Vector as Vector
-import Options.Applicative hiding (header)
+import Options.Applicative (
+  execParser,
+  fullDesc,
+  help,
+  helper,
+  info,
+  liftA2,
+  long,
+  metavar,
+  strOption,
+  progDesc,
+  short,
+  switch,
+  value,
+  (<**>),
+ )
 import Text.PrettyPrint.Boxes ((//))
 import qualified Text.PrettyPrint.Boxes as B
 import Text.Printf (printf)


### PR DESCRIPTION
Summary:
- Make it possible for consumers of `plutarch-benchmark` to pass `--output` flag that determines where CSV file will go. By default it will still go to the local `bench.csv`
- Use `optparse-applicative` instead of `getArgs`

Should we make outputting CSV files not the default behavior?