### PR TITLE
Optimize `ptrace`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 # Unreleased
 
+- Optimisations:
+  - `ptrace'` is now inlined, and is slightly more efficient in cpu, mem and script size.
+
 - `TermCont`: Parametrize by result type; add `MonadFail` instance; etc.
 
   Also, export from `Plutarch.TermCont`, and then from `Plutarch.Prelude` (TermCont is no longer exported by `Plutarch.Internal`).

--- a/Plutarch/Trace.hs
+++ b/Plutarch/Trace.hs
@@ -7,7 +7,7 @@ module Plutarch.Trace (ptrace, ptraceIfTrue, ptraceIfFalse, ptraceError) where
 
 import Plutarch.Internal.Other (Term, perror)
 #ifdef Development
-import Plutarch.Internal.Other (type (:-->), (#), phoistAcyclic, plet, pforce, pdelay)
+import Plutarch.Internal.Other (type (:-->), (#), plet, pforce, pdelay)
 #endif
 #ifdef Development
 import Plutarch.Bool (PBool, pif)
@@ -23,7 +23,7 @@ import qualified PlutusCore as PLC
 
 #ifdef Development
 ptrace' :: Term s (PString :--> a :--> a)
-ptrace' = phoistAcyclic $ pforce $ punsafeBuiltin PLC.Trace
+ptrace' = pforce $ punsafeBuiltin PLC.Trace
 #endif
 
 -- | Trace the given message before evaluating the argument.

--- a/plutarch-test/goldens/trace.dev=true.ptrace.bench.golden
+++ b/plutarch-test/goldens/trace.dev=true.ptrace.bench.golden
@@ -1,2 +1,2 @@
 one {"exBudgetCPU":388284,"exBudgetMemory":932,"scriptSizeBytes":16}
-two {"exBudgetCPU":806241,"exBudgetMemory":1864,"scriptSizeBytes":30}
+two {"exBudgetCPU":746695,"exBudgetMemory":1664,"scriptSizeBytes":28}

--- a/plutarch-test/goldens/trace.dev=true.ptrace.uplc.golden
+++ b/plutarch-test/goldens/trace.dev=true.ptrace.uplc.golden
@@ -1,2 +1,2 @@
 one (program 1.0.0 (force (force trace "foo" (delay ()))))
-two (program 1.0.0 ((\i0 -> force (i1 "foo" (delay (force (i1 "bar" (delay ())))))) (force trace)))
+two (program 1.0.0 (force (force trace "foo" (delay (force (force trace "bar" (delay ())))))))


### PR DESCRIPTION
Optimize `ptrace` by inlining its use. Merge after #297 

Improves on cpu, mem and script size for the case where `ptrace` is used more than once.

<img width="520" alt="image" src="https://user-images.githubusercontent.com/3998/154366890-329f0526-5fb0-4701-b3ad-690434c5aa12.png">

<img width="876" alt="image" src="https://user-images.githubusercontent.com/3998/154366904-25125285-f387-4536-9814-d9d9ca9987b2.png">
