### PR TITLE
Expose type alias of goldens monad

### DIFF
--- a/plutarch-test/src/Plutarch/Test.hs
+++ b/plutarch-test/src/Plutarch/Test.hs
@@ -16,6 +16,7 @@ module Plutarch.Test (
   plutarchDevFlagDescribe,
 
   -- * Golden testing
+  PlutarchGoldens,
   (@|),
   (@\),
   (@->),
@@ -54,6 +55,7 @@ import Plutarch.Benchmark (benchmarkScript')
 import Plutarch.Bool (PBool (PFalse, PTrue))
 import Plutarch.Evaluate (evaluateScript)
 import Plutarch.Test.Golden (
+  PlutarchGoldens,
   TermExpectation,
   compileD,
   evaluateScriptAlways,
@@ -106,7 +108,7 @@ ptraces p develTraces =
   case evaluateScript (compile p) of
     Left _ -> expectationFailure $ "Term failed to evaluate"
     Right (_, traceLog, _) -> do
-#ifdef Development 
+#ifdef Development
       traceLog `shouldBe` develTraces
 #else
       -- Tracing is disabled in non-developed modes, so we should expect an
@@ -128,7 +130,7 @@ plutarchDevFlagDescribe :: forall (outers :: [Type]) inner. TestDefM outers inne
 -- CPP support isn't great in fourmolu.
 {- ORMOLU_DISABLE -}
 plutarchDevFlagDescribe m =
-#ifdef Development 
+#ifdef Development
   describe "dev=true" m
 #else
   describe "dev=false" m

--- a/plutarch-test/src/Plutarch/Test/Golden.hs
+++ b/plutarch-test/src/Plutarch/Test/Golden.hs
@@ -1,4 +1,5 @@
 module Plutarch.Test.Golden (
+  PlutarchGoldens,
   pgoldenSpec,
   (@|),
   (@\),
@@ -52,6 +53,8 @@ data GoldenValue = GoldenValue
 -}
 class HasGoldenValue (t :: S -> PType -> Type) where
   mkGoldenValue :: forall a. (forall s. t s a) -> GoldenValue
+
+type PlutarchGoldens = ListSyntax (GoldenKey, GoldenValue)
 
 mkGoldenValue' :: ClosedTerm a -> Maybe Expectation -> GoldenValue
 mkGoldenValue' p mexp =
@@ -110,13 +113,13 @@ combineGoldens xs =
     (\(GoldenKey k, v) -> k <> " " <> v) <$> xs
 
 -- | Specify goldens for the given Plutarch program
-(@|) :: forall t a. HasGoldenValue t => GoldenKey -> (forall s. t s a) -> ListSyntax (GoldenKey, GoldenValue)
+(@|) :: forall t a. HasGoldenValue t => GoldenKey -> (forall s. t s a) -> PlutarchGoldens
 (@|) k v = listSyntaxAdd (k, mkGoldenValue v)
 
 infixr 0 @|
 
 -- | Add an expectation for the Plutarch program specified with (@|)
-(@\) :: GoldenKey -> ListSyntax (GoldenKey, GoldenValue) -> ListSyntax (GoldenKey, GoldenValue)
+(@\) :: GoldenKey -> PlutarchGoldens -> PlutarchGoldens
 (@\) = listSyntaxAddSubList
 
 {- | Create golden specs for pre/post-eval UPLC and benchmarks.
@@ -137,7 +140,7 @@ infixr 0 @|
   Hierarchy is represented by intercalating with a dot; for instance, the key
   for 'qux' will be "bar.qux".
 -}
-pgoldenSpec :: HasCallStack => ListSyntax (GoldenKey, GoldenValue) -> Spec
+pgoldenSpec :: HasCallStack => PlutarchGoldens -> Spec
 pgoldenSpec map = do
   name <- currentGoldenKey
   let bs = runListSyntax map


### PR DESCRIPTION
This pr adds PlutarchGoldens type alias for `ListSyntax (GoldenKey, GoldenValue)` and exposes it in Plutarch.Test. 
This is useful for writing combinators. 