### PR TITLE
Missing import in PIsDataRepr and PDataFields.md code example.

### DIFF
--- a/docs/Typeclasses/PIsDataRepr and PDataFields.md
+++ b/docs/Typeclasses/PIsDataRepr and PDataFields.md
@@ -303,7 +303,10 @@ import qualified GHC.Generics as GHC
 import Generics.SOP
 
 import Plutarch.Prelude
-import Plutarch.DataRepr (PIsDataReprInstances (PIsDataReprInstances))
+import Plutarch.DataRepr (
+  PDataFields,
+  PIsDataReprInstances (PIsDataReprInstances),
+ )
 
 newtype PFoo (s :: S) = PMkFoo (Term s (PDataRecord '["foo" ':= PByteString]))
   deriving stock (GHC.Generic)


### PR DESCRIPTION
The final code example in PIsDataRepr and PDataFields.md is missing the import of Plutarch.DataRepr.PDataFields needed to compile.