### PR TITLE
Replaced GHC.Exts.Any with Data.Void.Void

### DIFF
--- a/Plutarch/FFI.hs
+++ b/Plutarch/FFI.hs
@@ -16,7 +16,7 @@ module Plutarch.FFI (
 import Data.ByteString (ByteString)
 import Data.Kind (Constraint, Type)
 import Data.Text (Text)
-import GHC.Exts (Any)
+import Data.Void (Void)
 import GHC.Generics (Generic)
 import GHC.TypeLits (TypeError)
 import qualified GHC.TypeLits as TypeLits
@@ -91,8 +91,8 @@ foreignExport = unsafeForeignExport
 foreignImport :: p >~< t => CompiledCode t -> ClosedTerm p
 foreignImport = unsafeForeignImport
 
--- | Export Plutarch term of any type as @CompiledCode Any@.
-opaqueExport :: ClosedTerm p -> CompiledCode Any
+-- | Export Plutarch term of any type as @CompiledCode Void@.
+opaqueExport :: ClosedTerm p -> CompiledCode Void
 opaqueExport = unsafeForeignExport
 
 -- | Import compiled UPLC code of any type as a Plutarch opaque term.


### PR DESCRIPTION
It turns out that `plutus-tx-plugin` doesn't like `Any`:
```
GHC Core to PLC plugin: E042:Error: Unsupported feature: Kind: forall k. k
Context: Compiling kind: forall k. k
Context: Compiling type: GHC.Types.Any @Type
```
This PR puts `Void` in its place, which `plutus-tx-plugin` doesn't complain about.
