### PR TITLE
Avoid redundant evaluation in `@==`

### DIFF
--- a/plutarch-test/src/Plutarch/IntegerSpec.hs
+++ b/plutarch-test/src/Plutarch/IntegerSpec.hs
@@ -18,7 +18,7 @@ spec = do
         "fib" @\ do
           "lam" @| fib
           "app" @\ do
-            "9" @| fib # 9 @:-> \(p, bench) -> do
+            "9" @| fib # 9 @:-> \(p, _script, bench) -> do
               p `pshouldBe` (34 :: Term _ PInteger)
               bench `psatisfyWithinBenchmark` Benchmark 1_000_000_000 1_000_000 100
           "error" @| fib # perror @-> pfails

--- a/plutarch-test/src/Plutarch/Test.hs
+++ b/plutarch-test/src/Plutarch/Test.hs
@@ -181,11 +181,11 @@ plutarchDevFlagDescribe m =
 #endif
 {- ORMOLU_ENABLE -}
 
--- | Convenient alias for `@-> pshouldBe x`
+-- | Test that the Plutarch program evaluates to the given term
 (@==) :: ClosedTerm a -> ClosedTerm b -> TermExpectation a
 (@==) p x = p @:-> \(_, script, _) -> script `pscriptShouldBe` xScript
   where
-    xScript = fst . evalScriptAlwaysWithBenchmark . compile $ x
+    xScript = fst . evalScriptAlwaysWithBenchmark $ compile x
 
 infixr 1 @==
 


### PR DESCRIPTION
Also make `@:->` take the evaluated script as 3rd argument, as noted in https://github.com/Plutonomicon/plutarch/pull/347#issuecomment-1058238380