### PR TITLE
`plutarch-extra`: Export a Prelude for users of Plutarch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,12 @@
 
   Added by: [#329](https://github.com/Plutonomicon/plutarch/pull/329)
 
+- `plutarch-extra` export merged Prelude 
+   
+  Module: `Plutarch.PPrelude`
+
+  Added by: [#356](https://github.com/Plutonomicon/plutarch/pull/356)
+
 # 1.1.0
 
 - General repository changes.

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -6,6 +6,7 @@
 - [Overview](#overview)
   - [Compiling and Running](#compiling-and-running)
     - [Common Extensions and GHC options](#common-extensions-and-ghc-options)
+    - [Using the Plutarch Prelude](#using-the-plutarch-prelude)
     - [Evaluation](#evaluation)
   - [Syntax](#syntax)
     - [Constants](#constants)
@@ -98,6 +99,18 @@
 ### Common Extensions and GHC options
 
 You generally want to adhere to the same extensions and GHC options the [Plutarch repo](https://github.com/Plutonomicon/plutarch/blob/master/plutarch.cabal) uses.
+
+### Using the Plutarch Prelude
+
+Plutarch exports a Prelude (`Plutarch.Prelude`) that contains the most commonly used Plutarch functions, types and constructors.
+
+The Plutarch Prelude `Plutarch.Prelude` has no overlap with `base` Prelude, which is the reason why you can use both of them together
+without trouble. If you want to avoid importing `Plutarch.Prelude` in each of your modules, add the following to your `*.cabal` file:
+
+```haskell
+  mixins: base hiding (Prelude)
+                    , plutarch-preludes (PPrelude as Prelude)
+```
 
 ### Evaluation
 

--- a/plutarch-extra/plutarch-extra.cabal
+++ b/plutarch-extra/plutarch-extra.cabal
@@ -71,6 +71,11 @@ common deps
     , base
     , plutarch
 
+library plutarch-preludes
+  import:          c, deps
+  hs-source-dirs:  preludes
+  exposed-modules: PPrelude
+
 library
   import:          c, deps
   exposed-modules: Plutarch.Extra

--- a/plutarch-extra/preludes/PPrelude.hs
+++ b/plutarch-extra/preludes/PPrelude.hs
@@ -1,0 +1,6 @@
+module PPrelude ( module Prelude
+                , module Plutarch.Prelude
+                ) where 
+
+import Prelude
+import Plutarch.Prelude

--- a/plutarch-extra/preludes/PPrelude.hs
+++ b/plutarch-extra/preludes/PPrelude.hs
@@ -1,6 +1,7 @@
-module PPrelude ( module Prelude
-                , module Plutarch.Prelude
-                ) where 
+module PPrelude (
+  module Prelude,
+  module Plutarch.Prelude,
+) where
 
-import Prelude
 import Plutarch.Prelude
+import Prelude


### PR DESCRIPTION
## Changes

- added a new exported `Prelude` `PPrelude`
- updated the `GUIDE` to explain the usage 

## Notes

- this needs #351 
- I also tried to reexport [`relude`](https://github.com/kowainik/relude) which arguably is a nicer, more modern and safer alternative to `base`'s `Prelude` but they don't have ghc921 compat yet, so this will follow later