### PR TITLE
Add a few new sections to the guide + fixes

### DIFF
--- a/docs/Concepts/Hoisting.md
+++ b/docs/Concepts/Hoisting.md
@@ -34,10 +34,10 @@ You can factor out most of the logic to a Plutarch level function, and apply tha
 
 ```hs
 (#||) :: Term s PBool -> Term s PBool -> Term s PBool
-x #|| y = por # x # pdelay y
+x #|| y = pforce $ por # x # pdelay y
 
-por :: Term s (PBool :--> PDelayed PBool :--> PBool)
-por = phoistAcyclic $ plam $ \x y -> pif' # x # pconstant True # pforce y
+por :: Term s (PBool :--> PDelayed PBool :--> PDelayed PBool)
+por = phoistAcyclic $ plam $ \x y -> pif' # x # pdelay (pconstant True) # y
 ```
 
 In general the pattern goes like this:

--- a/docs/Concepts/Hoisting.md
+++ b/docs/Concepts/Hoisting.md
@@ -17,6 +17,14 @@ To solve this problem, Plutarch supports _hoisting_. Hoisting only works for _cl
 
 Hoisted terms are essentially moved to a top-level `plet`, i.e. it's essentially common sub-expression elimination. Do note that because of this, your hoisted term is **also strictly evaluated**, meaning that you _shouldn't_ hoist non-lazy complex computations (use [`pdelay`](./../Introduction/Delay%20and%20Force.md) to avoid this).
 
+In general, you should use `phoistAcyclic` on every top level function:
+
+```hs
+foo = phoistAcyclic $ plam $ \x -> <something complex>
+```
+
+As long as the Plutarch lambda you're hoisting does not have [free variables](https://wiki.haskell.org/Free_variable) (as Plutarch terms), you will be able to hoist it!
+
 ## Hoisting Operators
 
 For the sake of convenience, you often would want to use operators - which must be Haskell level functions. This is the case for `+`, `-`, `#==` and many more.

--- a/docs/README.md
+++ b/docs/README.md
@@ -136,6 +136,7 @@ Outside of the fundamental user guide, there are rules of thumb and general guid
 - [The isomorphism between `makeIsDataIndexed`, Haskell ADTs, and `PIsDataRepr`](./Tricks/makeIsDataIndexed,%20Haskell%20ADTs,%20and%20PIsDataRepr.md)
 - [Prefer statically building constants whenever possible](./Tricks/Prefer%20statically%20building%20constants.md)
 - [Figuring out the representation of a Plutarch type](./Tricks/Representation%20of%20Plutarch%20type.md)
+- [Prefer pattern matching on the result of `pmatch` immediately](./Tricks/Prefer%20matching%20on%20pmatch%20result%20immediately.md)
 
 # Common Issues and Troubleshooting
 

--- a/docs/Tricks.md
+++ b/docs/Tricks.md
@@ -12,3 +12,4 @@ This document discusses various rules of thumb and general trivia, aiming to mak
 - [The isomorphism between `makeIsDataIndexed`, Haskell ADTs, and `PIsDataRepr`](./Tricks/makeIsDataIndexed,%20Haskell%20ADTs,%20and%20PIsDataRepr.md)
 - [Prefer statically building constants whenever possible](./Tricks/Prefer%20statically%20building%20constants.md)
 - [Figuring out the representation of a Plutarch type](./Tricks/Representation%20of%20Plutarch%20type.md)
+- [Prefer pattern matching on the result of `pmatch` immediately](./Tricks/Prefer%20matching%20on%20pmatch%20result%20immediately.md)

--- a/docs/Tricks/Optimizing unhoistable lambdas.md
+++ b/docs/Tricks/Optimizing unhoistable lambdas.md
@@ -1,0 +1,21 @@
+# Optimizing unhoistable lambdas
+
+Often times, you'll be creating utility functions inside your Plutarch level functions that use free variables. In such cases, the function is unhoistable (i.e, you cannot use `phoistAcyclic` on it). However, it is likely that your goal is to use this utility function within your primary Plutarch level function several times. At which point, your unhoisted function will be inlined every time you use it and therefore increase script size.
+
+```hs
+pfoo :: Term s (PInteger :--> PBuiltinList PInteger :--> PInteger)
+pfoo = plam $ \x l ->
+  let innerf = plam $ \y -> x + y
+  in innerf # 42 + plength # (pmap # innerf # l)
+```
+
+Here, both uses of `innerf` will inline the lambda and then apply. This is problematic since you probably wanted to have a single lambda that you could simply reference with a variable.
+
+In these cases, you can simply [use `plet`](./Don't%20duplicate%20work.md) as you would have [in other places](../Usage/Avoid%20work%20duplication%20using%20plet.md)
+
+```hs
+pfoo :: Term s (PInteger :--> PBuiltinList PInteger :--> PInteger)
+pfoo = plam $ \x l ->
+  plet (plam $ \y -> x + y) $ \innerf ->
+    innerf # 42 + plength # (pmap # innerf # l)
+```

--- a/docs/Tricks/Prefer matching on pmatch result immediately.md
+++ b/docs/Tricks/Prefer matching on pmatch result immediately.md
@@ -1,0 +1,29 @@
+# Prefer pattern matching on the result of `pmatch` immediately
+
+You should always try and pattern match on the result of `pmatch` _immediately_. This is because the semantics of `pmatch` will make anything you write _before_ the pattern match be inlined for every single branch:
+
+```hs
+this :: Term s (PScriptPurpose :--> PInteger)
+this = plam $ \x -> pmatch x $ \l ->
+  plet $ 1 + 2 $ \i -> case l of
+    PMinting _ -> i + 3
+    PSpending _ -> i + 4
+    PRewarding _ -> i + 5
+    PCertifying _ -> i + 6
+```
+
+Notice how the above code `plet`s a computation _before_ matching on `l`, the `pmatch` result. This will make the `plet $ 1 + 2 $ \i -> i + <something>` be inlined in every branch of your pattern match! That is, not only will it compute the `1 + 2` every time, it will _also_ `plet` it, which introduced an extra lambda, only to immediately apply the lambda!
+
+You _should always_ match on the result immediately, whenever possible:
+
+```hs
+this :: Term s (PScriptPurpose :--> PInteger)
+this = plam $ \x -> plet $ 1 + 2 $ \i ->
+  pmatch x $ \case
+    PMinting _ -> i + 3
+    PSpending _ -> i + 4
+    PRewarding _ -> i + 5
+    PCertifying _ -> i + 6
+```
+
+This applies much the same with `do` syntax (whether with `TermCont` or with `QualifiedDo`). Try to use inline partial pattern matching (e.g `PMinting _ <- pmatch x`), or pattern match on the very next line (e.g `l <- pmatch x; case l of ...`).

--- a/docs/Tricks/makeIsDataIndexed, Haskell ADTs, and PIsDataRepr.md
+++ b/docs/Tricks/makeIsDataIndexed, Haskell ADTs, and PIsDataRepr.md
@@ -67,3 +67,17 @@ data TxInfo = TxInfo
 ```
 
 The _field names_ don't matter though. They are merely labels that don't exist at runtime.
+
+## What about `newtype`s?
+
+Of course, this does not apply when you're using `newtype` derivation (e.g `derive newtype ...`) to derive `FromData` or `ToData` for your PlutusTx types. In that case, the `Data` representation is simply the same as the inner type.
+
+```hs
+import qualified PlutusTx
+import PlutusTx.Prelude
+
+newtype CurrencySymbol = CurrencySymbol { unCurrencySymbol :: BuiltinByteString }
+  deriving newtype (PlutusTx.ToData, PlutusTx.FromData, PlutusTx.UnsafeFromData)
+```
+
+Here, for example, `CurrencySymbol` has the very same `Data` representation as `BuiltinByteString`. No extra information is added.

--- a/docs/Typeclasses/PIsDataRepr and PDataFields.md
+++ b/docs/Typeclasses/PIsDataRepr and PDataFields.md
@@ -23,6 +23,7 @@ foo = plam $ \ctx -> P.do
     PRewarding _ -> "It's rewarding!"
     PCertifying _ -> "It's certifying!"
 ```
+
 > Note: The above snippet uses GHC 9 features (`QualifiedDo`). Be sure to check out [Do syntax with `TermCont`](./../Usage/Do%20syntax%20with%20TermCont.md).
 
 Of course, just like `ScriptContext` - `PScriptContext` is represented as a `Data` value in Plutus Core. Plutarch just lets you keep track of the _exact representation_ of it within the type system.
@@ -232,6 +233,14 @@ data PVehicle (s :: S)
   | PTwoWheeler (Term s (PDataRecord '["_0" ':= PInteger, "_1" ':= PInteger]))
   | PImmovableBox (Term s (PDataRecord '[]))
 ```
+
+Each field type must also have a `PIsData` instance. We've fulfilled this criteria above as `PInteger` does indeed have a `PIsData` instance. However, think of `PBuiltinList`s, as an example. `PBuiltinList`'s `PIsData` instance is restricted to only `PAsData` elements.
+
+```hs
+instance PIsData a => PIsData (PBuiltinList (PAsData a))
+```
+
+Thus, you can use `PBuiltinList (PAsData PInteger)` as a field type, but not `PBuiltinList PInteger`.
 
 > Note: The constructor ordering in `PVehicle` matters! If you used [`makeIsDataIndexed`](https://playground.plutus.iohkdev.io/doc/haddock/plutus-tx/html/PlutusTx.html#v:makeIsDataIndexed) on `Vehicle` to assign an index to each constructor - the Plutarch type's constructors must follow the same indexing order.
 >

--- a/docs/Typeclasses/PIsDataRepr and PDataFields.md
+++ b/docs/Typeclasses/PIsDataRepr and PDataFields.md
@@ -34,7 +34,7 @@ newtype PScriptContext (s :: S)
   = PScriptContext
       ( Term
           s
-          ( PDataRecor, numbers less than 10 should be written as a word.
+          ( PDataRecord
               '[ "txInfo" ':= PTxInfo
                , "purpose" ':= PScriptPurpose
                ]

--- a/docs/Typeclasses/PlutusType, PCon, and PMatch.md
+++ b/docs/Typeclasses/PlutusType, PCon, and PMatch.md
@@ -5,8 +5,8 @@
 ```hs
 class (PCon a, PMatch a) => PlutusType (a :: k -> Type) where
   type PInner a (b' :: k -> Type) :: k -> Type
-  pcon' :: forall s. a s -> forall b. Term s (PInner a b)
-  pmatch' :: forall s c. (forall b. Term s (PInner a b)) -> (a s -> Term s c) -> Term s c
+  pcon' :: forall s b. a s -> Term s (PInner a b)
+  pmatch' :: forall s b. Term s (PInner a b) -> (a s -> Term s b) -> Term s b
 ```
 
 > Note: You don't need to look too much into the types! After all, you'll be using `pcon` and `pmatch`, rather than `pcon'` and `pmatch'`.
@@ -19,7 +19,6 @@ data PMaybe a s = PJust (Term s a) | PNothing
 
 instance PlutusType (PMaybe a) where
   type PInner (PMaybe a) b = (a :--> b) :--> PDelayed b :--> b
-  pcon' :: forall s. PMaybe a s -> forall b. Term s (PInner (PMaybe a) b)
   pcon' (PJust x) = plam $ \f (_ :: Term _ _) -> f # x
   pcon' PNothing = plam $ \_ g -> pforce g
   pmatch' x f = x # (plam $ \inner -> f (PJust inner)) # (pdelay $ f PNothing)

--- a/docs/Typeclasses/PlutusType, PCon, and PMatch.md
+++ b/docs/Typeclasses/PlutusType, PCon, and PMatch.md
@@ -40,6 +40,14 @@ All `PlutusType` instances get `PCon` and `PMatch` instances for free!
 
 For types that cannot easily be both `PCon` and `PMatch` - feel free to implement just one of them! However, in general, **prefer implementing `PlutusType`**!
 
+Another feature of `PlutusType` instances is that you can extract out the *inner* type of any `PlutusType` instance! Above, the inner type (or representation) of `PMaybe` was a function. You can use `pto` to safely take this inner type out-
+
+```hs
+pto :: Term s a -> (forall b. Term s (PInner a b))
+```
+
+This is quite useful when working with `newtype`s. Notice how `PCurrencySymbol`, for example, is simply a newtype to a `PByteString`. Its `PInner` is also `PByteString`. To be able to use functions that operate on `PByteString`s with your `PCurrencySymbol`, you can simply take out the `PByteString` using `pto`!
+
 ## Implementing `PlutusType` for your own types (Scott Encoding)
 
 If you want to represent your data type with [Scott encoding](./../Concepts/Data%20and%20Scott%20encoding.md#scott-encoding) (and therefore don't need to make it `Data` encoded), you should simply derive it generically:


### PR DESCRIPTION
- Fix `por` and `#||` definition in "Hoisting operators" section
- Fix `pmatch'` and `pcon'` type signature in PlutusType section
- Fix a typo in PIsDataRepr section
- Explicitly note that `PDataRecord` fields should have a `PIsData` instance (and that relates to `PBuiltinList`).
- Add note about `newtype`s in the Isomorphism between PlutusTx and Plutarch data encoded types section
- Add information on `pto` in the PlutusType section
- Code example of hoisting in the primary "Hoisting" section.
- Add note on when it may be a good idea to `plet` fields of scott encoded types prior to construction with `pcon`.
- Add new subsection under "Tricks", encouraging users to pattern match on the `pmatch` result immediately.
- Add section on `plet`ing lambdas rather than hoisting them, when it's not possible to hoist them.