### PR TITLE
Simplify constraints in old Generic code

### DIFF
--- a/Plutarch/Bool.hs
+++ b/Plutarch/Bool.hs
@@ -32,7 +32,7 @@ import Generics.SOP (
   hcliftA2,
  )
 import Plutarch.Internal (punsafeAsClosedTerm)
-import Plutarch.Internal.Generic (PCode, PGeneric, pfrom)
+import Plutarch.Internal.Generic (PCode, PGeneric, gpfrom)
 import Plutarch.Internal.Other (
   DerivePNewtype,
   PDelayed,
@@ -154,7 +154,7 @@ gpeq =
       plam $ \x y ->
         pmatch x $ \x' ->
           pmatch y $ \y' ->
-            gpeq' @t (pfrom x') (pfrom y')
+            gpeq' @t (gpfrom x') (gpfrom y')
 
 gpeq' ::
   forall a s.

--- a/Plutarch/DataRepr/Internal.hs
+++ b/Plutarch/DataRepr/Internal.hs
@@ -85,8 +85,7 @@ import Plutarch.Builtin (
 import Plutarch.DataRepr.Internal.HList (type Drop, type IndexList)
 import Plutarch.Integer (PInteger)
 import Plutarch.Internal (S (SI))
-import Plutarch.Internal.Generic (MkSum (mkSum), PCode, PGeneric, pfrom)
-import qualified Plutarch.Internal.Generic as G
+import Plutarch.Internal.Generic (MkSum (mkSum), PCode, PGeneric, gpfrom, gpto)
 import Plutarch.Lift (PConstant, PConstantRepr, PConstanted, PLift, pconstant, pconstantFromRepr, pconstantToRepr)
 import Plutarch.List (PListLike (pnil), pcons, pdrop, phead, ptail, ptryIndex)
 import Plutarch.TermCont (TermCont, hashOpenTerm, runTermCont)
@@ -286,7 +285,7 @@ class (PMatch a, PIsData a) => PIsDataRepr (a :: PType) where
   pconRepr x = punsafeCoerce expected
     where
       expected :: Term _ (PAsData (PBuiltinPair PInteger (PBuiltinList PData)))
-      expected = gpconRepr @a $ pfrom x
+      expected = gpconRepr @a $ gpfrom x
 
   pmatchRepr :: forall s b. Term s (PDataSum (PIsDataReprRepr a)) -> (a s -> Term s b) -> Term s b
   default pmatchRepr ::
@@ -337,7 +336,7 @@ instance
   MkDataReprHandler s a n (r ': rs)
   where
   mkDataReprHandler f =
-    DRHCons (f . G.pto . mkSOP . mkProduct) $
+    DRHCons (f . gpto . mkSOP . mkProduct) $
       mkDataReprHandler @s @a @(n + 1) @rs f
     where
       mkProduct :: Term s (PDataRecord fs) -> NP (Term s) r

--- a/Plutarch/DataRepr/Internal.hs
+++ b/Plutarch/DataRepr/Internal.hs
@@ -38,22 +38,15 @@ import GHC.TypeLits (
 import Generics.SOP (
   All,
   All2,
-  AllZipN,
   Code,
   Generic,
-  I (I),
   K (K),
-  LiftedCoercible,
   NP (Nil, (:*)),
-  POP,
   SListI,
   SOP (SOP),
-  from,
   hcmap,
   hcollapse,
-  hfromI,
   hindex,
-  to,
  )
 import Plutarch (
   Dig,
@@ -92,8 +85,8 @@ import Plutarch.Builtin (
 import Plutarch.DataRepr.Internal.HList (type Drop, type IndexList)
 import Plutarch.Integer (PInteger)
 import Plutarch.Internal (S (SI))
-import Plutarch.Internal.Generic (MkSum (mkSum))
-import Plutarch.Internal.TypeFamily (ToPType2)
+import Plutarch.Internal.Generic (MkSum (mkSum), PCode, PGeneric, pfrom)
+import qualified Plutarch.Internal.Generic as G
 import Plutarch.Lift (PConstant, PConstantRepr, PConstanted, PLift, pconstant, pconstantFromRepr, pconstantToRepr)
 import Plutarch.List (PListLike (pnil), pcons, pdrop, phead, ptail, ptryIndex)
 import Plutarch.TermCont (TermCont, hashOpenTerm, runTermCont)
@@ -151,10 +144,10 @@ data PLabeledType = Symbol := PType
 
 {- Get the product types of a data record sum constructor
 -}
-type PDataRecordFields :: [Type] -> [PLabeledType]
+type PDataRecordFields :: [PType] -> [PLabeledType]
 type family PDataRecordFields as where
   PDataRecordFields '[] = '[]
-  PDataRecordFields '[Term s (PDataRecord fs)] = fs
+  PDataRecordFields '[(PDataRecord fs)] = fs
   PDataRecordFields '[t] = TypeError ( 'Text "Expected PDataRecord" ':<>: 'Text "but got" ':<>: 'ShowType t)
   PDataRecordFields ts = TypeError ( 'Text "Expected none or PDataRecord" ':<>: 'Text "but got" ':<>: 'ShowType ts)
 
@@ -162,7 +155,7 @@ type family PDataRecordFields as where
 
 NOTE: Unfortunately we can't write a generic FMap due to ghc's arity limitations.
 -}
-type PDataRecordFields2 :: [[Type]] -> [[PLabeledType]]
+type PDataRecordFields2 :: [[PType]] -> [[PLabeledType]]
 type family PDataRecordFields2 as where
   PDataRecordFields2 '[] = '[]
   PDataRecordFields2 (a ': as) = PDataRecordFields a ': PDataRecordFields2 as
@@ -276,81 +269,81 @@ newtype PIsDataReprInstances (a :: PType) (s :: S) = PIsDataReprInstances (a s)
 -- TODO: This 'PMatch' constraint needs to be changed to 'PlutusType (breaking change).
 class (PMatch a, PIsData a) => PIsDataRepr (a :: PType) where
   type PIsDataReprRepr a :: [[PLabeledType]]
-  type PIsDataReprRepr a = PDataRecordFields2 (Code (a 'SI))
+  type PIsDataReprRepr a = PDataRecordFields2 (PCode 'SI a)
 
   pconRepr :: a s -> Term s (PDataSum (PIsDataReprRepr a))
   default pconRepr ::
     forall s code pcode.
-    ( Generic (a s)
+    ( PGeneric s a
     , code ~ Code (a s)
-    , pcode ~ ToPType2 code
+    , pcode ~ PCode s a
     , All SListI pcode
     , All Singleton code
     , All2 IsBuiltinList pcode
-    , AllZipN POP (LiftedCoercible I (Term s)) code pcode
     ) =>
     a s ->
     Term s (PDataSum (PIsDataReprRepr a))
   pconRepr x = punsafeCoerce expected
     where
       expected :: Term _ (PAsData (PBuiltinPair PInteger (PBuiltinList PData)))
-      expected = gpconRepr @a $ from x
+      expected = gpconRepr @a $ pfrom x
 
   pmatchRepr :: forall s b. Term s (PDataSum (PIsDataReprRepr a)) -> (a s -> Term s b) -> Term s b
   default pmatchRepr ::
-    forall s b code.
+    forall s b code pcode.
     ( code ~ Code (a s)
-    , PDataRecordFields2 code ~ PIsDataReprRepr a
-    , MkDataReprHandler s a 0 code
+    , pcode ~ PCode s a
+    , PDataRecordFields2 pcode ~ PIsDataReprRepr a
+    , MkDataReprHandler s a 0 pcode
     ) =>
     Term s (PDataSum (PIsDataReprRepr a)) ->
     (a s -> Term s b) ->
     Term s b
   pmatchRepr dat =
-    pmatchDataSum dat . mkDataReprHandler @s @a @0 @code
+    pmatchDataSum dat . mkDataReprHandler @s @a @0 @pcode
 
 gpconRepr ::
   forall a s code pcode.
   ( Generic (a s)
   , code ~ Code (a s)
-  , pcode ~ ToPType2 code
+  , pcode ~ PCode s a
   , All SListI pcode
   , All Singleton code
   , All2 IsBuiltinList pcode
-  , AllZipN POP (LiftedCoercible I (Term s)) code pcode
   ) =>
-  SOP I (Code (a s)) ->
+  SOP (Term s) pcode ->
   Term s (PAsData (PBuiltinPair PInteger (PBuiltinList PData)))
 gpconRepr x = pconstrBuiltin # pconstant (toInteger $ hindex sop) # head (hcollapse sop)
   where
     sop :: SOP (K (Term s (PBuiltinList PData))) pcode
-    sop = hcmap (Proxy @IsBuiltinList) (K . dataListFrom) $ hfromI x
+    sop = hcmap (Proxy @IsBuiltinList) (K . dataListFrom) x
 
 -- | Create a `DataReprhandlers` starting from `n`th sum constructor
-class MkDataReprHandler (s :: S) (a :: PType) (n :: Nat) (rest :: [[Type]]) where
+class MkDataReprHandler (s :: S) (a :: PType) (n :: Nat) (rest :: [[PType]]) where
   mkDataReprHandler :: forall out. (a s -> Term s out) -> DataReprHandlers out (PDataRecordFields2 rest) s
 
 instance MkDataReprHandler s a n '[] where
   mkDataReprHandler _ = DRHNil
 
 instance
-  ( Generic (a s)
+  ( PGeneric s a
   , code ~ Code (a s)
-  , r ~ IndexList n code
-  , r ~ '[Term s (PDataRecord fs)]
-  , MkSum n code
+  , pcode ~ PCode s a
+  , r ~ IndexList n pcode
+  , r ~ '[(PDataRecord fs)]
+  , MkSum n pcode (Term s)
   , MkDataReprHandler s a (n + 1) rs
   ) =>
   MkDataReprHandler s a n (r ': rs)
   where
   mkDataReprHandler f =
-    DRHCons (f . to . mkSOP . mkProduct) $
+    DRHCons (f . G.pto . mkSOP . mkProduct) $
       mkDataReprHandler @s @a @(n + 1) @rs f
     where
-      mkProduct :: Term s (PDataRecord fs) -> NP I r
-      mkProduct x = I x :* Nil
-      mkSOP :: NP I r -> SOP I (Code (a s))
-      mkSOP = SOP . mkSum @n @code
+      mkProduct :: Term s (PDataRecord fs) -> NP (Term s) r
+      mkProduct x = x :* Nil
+      mkSOP :: NP (Term s) r -> SOP (Term s) (PCode s a)
+      mkSOP = SOP . mkSum @_ @n @pcode
 
 pasDataSum :: PIsDataRepr a => Term s a -> Term s (PDataSum (PIsDataReprRepr a))
 pasDataSum = punsafeCoerce

--- a/Plutarch/Internal/Generic.hs
+++ b/Plutarch/Internal/Generic.hs
@@ -8,6 +8,7 @@ module Plutarch.Internal.Generic (
   PGeneric,
   PCode,
   pfrom,
+  pto,
 
   -- * Helpers for when existing generics-sop combinators are insufficient.
   MkSum (mkSum),
@@ -15,7 +16,7 @@ module Plutarch.Internal.Generic (
 
 import Data.Kind (Constraint, Type)
 import GHC.TypeLits (Nat, type (-))
-import Generics.SOP (All, AllZip, Code, Generic (from), I, LiftedCoercible, NP, NS (S, Z), SOP, SameShapeAs, Top, hfromI)
+import Generics.SOP (All, AllZip, Code, Generic (from, to), I, LiftedCoercible, NP, NS (S, Z), SOP, SameShapeAs, Top, hfromI, htoI)
 import Generics.SOP.Constraint (AllZipF)
 import Plutarch.DataRepr.Internal.HList.Utils (IndexList)
 import Plutarch.Internal (PType, S, Term)
@@ -25,10 +26,11 @@ import Plutarch.Internal.TypeFamily (ToPType2)
 type PGeneric :: S -> PType -> Constraint
 type PGeneric s a =
   ( Generic (a s)
-  , SameShapeAs (Code (a s)) (ToPType2 (Code (a s)))
-  , SameShapeAs (ToPType2 (Code (a s))) (Code (a s))
-  , AllZipF (AllZip (LiftedCoercible I (Term s))) (Code (a s)) (ToPType2 (Code (a s)))
-  , All Top (ToPType2 (Code (a s)))
+  , SameShapeAs (Code (a s)) (PCode s a)
+  , SameShapeAs (PCode s a) (Code (a s))
+  , AllZipF (AllZip (LiftedCoercible I (Term s))) (Code (a s)) (PCode s a)
+  , AllZipF (AllZip (LiftedCoercible (Term s) I)) (PCode s a) (Code (a s))
+  , All Top (PCode s a)
   )
 
 -- | Like `Code` but for Plutarch types
@@ -41,6 +43,10 @@ type PCode s a = ToPType2 (Code (a s))
 pfrom :: PGeneric s a => a s -> SOP (Term s) (PCode s a)
 pfrom = hfromI . from
 
+-- | Like `to` but for Plutarch terms. Analogous to `pfrom`.
+pto :: PGeneric s a => SOP (Term s) (PCode s a) -> a s
+pto = to . htoI
+
 {- |
 Infrastructure to create a single sum constructor given its type index and value.
 
@@ -50,17 +56,17 @@ Infrastructure to create a single sum constructor given its type index and value
 
 It is type-checked that the `x` here matches the type of nth constructor of `a`.
 -}
-class MkSum (idx :: Nat) (xss :: [[Type]]) where
-  mkSum :: NP I (IndexList idx xss) -> NS (NP I) xss
+class MkSum (idx :: Nat) (xss :: [[k]]) (f :: k -> Type) where
+  mkSum :: NP f (IndexList idx xss) -> NS (NP f) xss
 
-instance {-# OVERLAPPING #-} MkSum 0 (xs ': xss) where
+instance {-# OVERLAPPING #-} MkSum 0 (xs ': xss) f where
   mkSum = Z
 
 instance
   {-# OVERLAPPABLE #-}
-  ( MkSum (idx - 1) xss
+  ( MkSum (idx - 1) xss f
   , IndexList idx (xs ': xss) ~ IndexList (idx - 1) xss
   ) =>
-  MkSum idx (xs ': xss)
+  MkSum idx (xs ': xss) f
   where
-  mkSum x = S $ mkSum @(idx - 1) @xss x
+  mkSum x = S $ mkSum @_ @(idx - 1) @xss x

--- a/Plutarch/Internal/Generic.hs
+++ b/Plutarch/Internal/Generic.hs
@@ -7,8 +7,8 @@ module Plutarch.Internal.Generic (
   -- * Plutarch adapters for generics-sop API
   PGeneric,
   PCode,
-  pfrom,
-  pto,
+  gpfrom,
+  gpto,
 
   -- * Helpers for when existing generics-sop combinators are insufficient.
   MkSum (mkSum),
@@ -40,12 +40,12 @@ type PCode s a = ToPType2 (Code (a s))
 
   Instead of `I`, this uses `Term s` as the container type.
 -}
-pfrom :: PGeneric s a => a s -> SOP (Term s) (PCode s a)
-pfrom = hfromI . from
+gpfrom :: PGeneric s a => a s -> SOP (Term s) (PCode s a)
+gpfrom = hfromI . from
 
--- | Like `to` but for Plutarch terms. Analogous to `pfrom`.
-pto :: PGeneric s a => SOP (Term s) (PCode s a) -> a s
-pto = to . htoI
+-- | Like `to` but for Plutarch terms. Analogous to `gpfrom`.
+gpto :: PGeneric s a => SOP (Term s) (PCode s a) -> a s
+gpto = to . htoI
 
 {- |
 Infrastructure to create a single sum constructor given its type index and value.

--- a/Plutarch/Internal/PlutusType.hs
+++ b/Plutarch/Internal/PlutusType.hs
@@ -21,7 +21,7 @@ import Generics.SOP (
 import Plutarch.DataRepr.Internal.HList.Utils (IndexList)
 import Plutarch.Internal (PType, S, Term, pforce, plam', punsafeCoerce, (:-->))
 import qualified Plutarch.Internal as PI
-import Plutarch.Internal.Generic (MkSum (mkSum), PCode, PGeneric, pfrom, pto)
+import Plutarch.Internal.Generic (MkSum (mkSum), PCode, PGeneric, gpfrom, gpto)
 import Plutarch.Internal.PLam ((#))
 import Plutarch.Internal.TypeFamily (ToPType, ToPType2)
 
@@ -100,7 +100,7 @@ class (PCon a, PMatch a) => PlutusType (a :: PType) where
     ) =>
     a s ->
     Term s (PInner a b)
-  pcon' x = gpcon @a @b $ pfrom x
+  pcon' x = gpcon @a @b $ gpfrom x
 
   pmatch' :: forall s b. (Term s (PInner a b)) -> (a s -> Term s b) -> Term s b
   default pmatch' ::
@@ -115,7 +115,7 @@ class (PCon a, PMatch a) => PlutusType (a :: PType) where
     (Term s (PInner a b)) ->
     (a s -> Term s b) ->
     Term s b
-  pmatch' x f = gpmatch @a x (f . pto)
+  pmatch' x f = gpmatch @a x (f . gpto)
 
 instance {-# OVERLAPPABLE #-} PlutusType a => PMatch a where
   pmatch x f = pmatch' (punsafeCoerce x) f

--- a/Plutarch/Internal/PlutusType.hs
+++ b/Plutarch/Internal/PlutusType.hs
@@ -9,28 +9,19 @@ module Plutarch.Internal.PlutusType (
 ) where
 
 import Data.Kind (Type)
-import Data.SOP.Constraint (AllZipF)
 import GHC.TypeLits (ErrorMessage (Text), Nat, TypeError, type (+))
 import Generics.SOP (
   All,
-  AllZip,
-  AllZipN,
-  Generic (..),
-  I,
-  LiftedCoercible,
-  NP (..),
-  NS (..),
-  Prod,
+  Generic (Code),
+  NP (Nil, (:*)),
+  NS (S, Z),
   SOP (SOP),
-  SameShapeAs,
   Top,
-  hcoerce,
-  unSOP,
  )
 import Plutarch.DataRepr.Internal.HList.Utils (IndexList)
 import Plutarch.Internal (PType, S, Term, pforce, plam', punsafeCoerce, (:-->))
 import qualified Plutarch.Internal as PI
-import Plutarch.Internal.Generic (MkSum (mkSum))
+import Plutarch.Internal.Generic (MkSum (mkSum), PCode, PGeneric, pfrom, pto)
 import Plutarch.Internal.PLam ((#))
 import Plutarch.Internal.TypeFamily (ToPType, ToPType2)
 
@@ -99,27 +90,24 @@ class (PCon a, PMatch a) => PlutusType (a :: PType) where
   default pcon' ::
     forall s b code pcode.
     ( code ~ Code (a s)
-    , pcode ~ ToPType2 code
-    , Generic (a s)
+    , pcode ~ PCode s a
+    , PGeneric s a
     , GPCon pcode b s
     , PLamL (ScottList' s pcode b) b s
     , ScottFn' (ScottList s pcode b) b ~ PInner a b
     , ScottFn (ScottList' s pcode b) b ~ PInner a b
-    , AllZipF (AllZip (LiftedCoercible I (Term s))) code pcode
-    , SameShapeAs code pcode
-    , SameShapeAs pcode code
     , All Top pcode
     ) =>
     a s ->
     Term s (PInner a b)
-  pcon' x = gpcon @a @b $ from x
+  pcon' x = gpcon @a @b $ pfrom x
 
   pmatch' :: forall s b. (Term s (PInner a b)) -> (a s -> Term s b) -> Term s b
   default pmatch' ::
     forall s b code pcode.
     ( code ~ Code (a s)
-    , pcode ~ ToPType2 code
-    , Generic (a s)
+    , pcode ~ PCode s a
+    , PGeneric s a
     , AppL b (ScottList' s pcode b)
     , GPMatch a 0 code b s
     , PInner a b ~ ScottFn (ScottList' s pcode b) b
@@ -127,7 +115,7 @@ class (PCon a, PMatch a) => PlutusType (a :: PType) where
     (Term s (PInner a b)) ->
     (a s -> Term s b) ->
     Term s b
-  pmatch' x f = gpmatch @a x (f . to)
+  pmatch' x f = gpmatch @a x (f . pto)
 
 instance {-# OVERLAPPABLE #-} PlutusType a => PMatch a where
   pmatch x f = pmatch' (punsafeCoerce x) f
@@ -147,23 +135,18 @@ class PMatch a where
 gpcon ::
   forall a c s code pcode.
   ( PlutusType a
-  , Generic (a s)
+  , PGeneric s a
   , code ~ Code (a s)
-  , pcode ~ ToPType2 code
+  , pcode ~ PCode s a
   , GPCon pcode c s
   , PLamL (ScottList' s pcode c) c s
   , ScottFn (ScottList' s pcode c) c ~ ScottFn' (ScottList s pcode c) c
-  , AllZipN (Prod SOP) (LiftedCoercible I (Term s)) code pcode
   ) =>
-  SOP I (Code (a s)) ->
+  SOP (Term s) pcode ->
   Term s (ScottFn' (ScottList s pcode c) c)
-gpcon val =
+gpcon (SOP val) =
   plamL @(ScottList' s pcode c) @c $ \(f :: NP (Term s) (ScottList' s pcode c)) ->
-    gpcon' @pcode @c @s f $
-      unSOP $ pSop val
-  where
-    pSop :: AllZipN (Prod SOP) (LiftedCoercible I (Term s)) xss (ToPType2 xss) => SOP I xss -> SOP (Term s) (ToPType2 xss)
-    pSop = hcoerce
+    gpcon' @pcode @c @s f val
 
 {- |
   `gpcon'`, given a *partial* scott encoding (as a `PLamL`) and a sum choice, applies
@@ -188,14 +171,14 @@ instance (GPCon xs c s, AppL c x) => GPCon (x ': xs) c s where
 -}
 gpmatch ::
   forall a s c code pcode.
-  ( Generic (a s)
+  ( PGeneric s a
   , code ~ Code (a s)
-  , pcode ~ ToPType2 code
+  , pcode ~ PCode s a
   , AppL c (ScottList' s pcode c)
   , GPMatch a 0 code c s
   ) =>
   Term s (ScottFn (ScottList' s pcode c) c) ->
-  (SOP I (Code (a s)) -> Term s c) ->
+  (SOP (Term s) pcode -> Term s c) ->
   Term s c
 gpmatch x f =
   x `appL` gpmatch' @a @0 @code @c @s f
@@ -205,39 +188,25 @@ gpmatch x f =
   scott encoding function.
 -}
 class GPMatch (a :: PType) (n :: Nat) (xss :: [[Type]]) (c :: PType) (s :: S) where
-  gpmatch' :: (SOP I (Code (a s)) -> Term s c) -> NP (Term s) (ScottList' s (ToPType2 xss) c)
+  gpmatch' :: (SOP (Term s) (PCode s a) -> Term s c) -> NP (Term s) (ScottList' s (ToPType2 xss) c)
 
 instance GPMatch a n '[] c s where
   gpmatch' _ = Nil
 
 instance
   ( code ~ Code (a s)
-  , xs ~ IndexList n code
+  , ToPType xs ~ IndexList n (PCode s a)
   , GPMatch a (n + 1) xss c s
   , PLamL (ToPType xs) c s
-  , MkSum n (Code (a s))
-  , AllZipF (LiftedCoercible (Term s) I) (ToPType xs) xs
-  , SameShapeAs xs (ToPType xs)
-  , SameShapeAs (ToPType xs) xs
+  , MkSum n (PCode s a) (Term s)
   , All Top (ToPType xs)
   , All Top xs
   ) =>
   GPMatch a n (xs : xss) c s
   where
   gpmatch' f =
-    plamL @(ToPType xs) @c (f . SOP . mkSum @n @(Code (a s)) . unPsop)
+    plamL @(ToPType xs) @c (f . SOP . mkSum @_ @n @(PCode s a) @(Term s))
       :* gpmatch' @a @(n + 1) @xss @c @s f
-    where
-      unPsop ::
-        ( AllZipF (LiftedCoercible (Term s) I) (ToPType xs) xs
-        , SameShapeAs xs (ToPType xs)
-        , SameShapeAs (ToPType xs) xs
-        , All Top (ToPType xs)
-        , All Top xs
-        ) =>
-        NP (Term s) (ToPType xs) ->
-        NP I xs
-      unPsop = hcoerce
 
 {- |
   `plamL` is like `plamL'`, but pdelays the 0-arity case.


### PR DESCRIPTION
- Add `pto`
- Use `SOP (Term s)` throughout -- via use of `PGeneric`, `pfrom`, `pto` -- in older Generic code to avoid having to `hcoerce` midway (which is arguably more complex). This also simplifies the constraints in them. 

<img width="210" alt="image" src="https://user-images.githubusercontent.com/3998/157314584-cd1f7d68-0b90-42f6-9122-5ebf150a669c.png">
