### PR TITLE
Nix'ify docs website, and check for broken links in CI

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+flake.lock linguist-generated=true

--- a/docs/DEVGUIDE.md
+++ b/docs/DEVGUIDE.md
@@ -58,7 +58,7 @@ Parts of the [Pluto guide](https://github.com/Plutonomicon/pluto/blob/main/GUIDE
 
 ## Plutus Core constants (UNSAFE)
 
-> **NOTE**: The following information is almost never necessary with the existence of `pconstant`. Refer to [constant building](./GUIDE.md#constants) and [`PConstant`/`PLift`](./GUIDE.md#pconstant--plift) section of the Plutarch user guide.
+> **NOTE**: The following information is almost never necessary with the existence of `pconstant`. Refer to [constant building](Introduction/Plutarch%20Terms/Plutarch%20Constants.md) and [`PConstant`/`PLift`](./Typeclasses/PConstant%20and%20PLift.md) section of the Plutarch user guide.
 
 Often, you will need to build a Plutus core constant. You can do this using `Some` and `ValueOf`. Here's how `pcon PTrue` creates a Plutarch term that actually evaluates to a Plutus core constant representing a boolean:
 
@@ -238,7 +238,7 @@ mockCtx =
 Right (Program () (Version () 1 0 0) (Constant () (Some (ValueOf data (Constr 0 [List [Constr 0 [Constr 0 [Constr 0 [B ""],I 1],Constr 0 [Constr 0 [Constr 0 [B "\SOH#"],Constr 1 []],Map [],Constr 1 []]]],List [],Map [],Map [],List [],List [],Constr 0 [Constr 0 [Constr 1 [I 1],Constr 1 []],Constr 0 [Constr 1 [I 2],Constr 1 []]],List [],List [],Constr 0 [B ""]])))))
 ```
 
-> Aside: You can find the definition of `evalWithArgsT` above - [Compiling and Running](./GUIDE.md#compiling-and-running).
+> Aside: You can find the definition of `evalWithArgsT` above - [Compiling and Running](./README.md#compiling-and-running).
 
 But we're not done yet! We want `txInfoInputs`. You may have noticed where exactly it is located on the above output. See that `List …`? Inside the outermost `Constr`'s fields? That's our `txInfoInputs`!
 

--- a/docs/DEVGUIDE.md
+++ b/docs/DEVGUIDE.md
@@ -17,6 +17,7 @@ Looking to contribute to Plutarch? Looking for functionalities that are not curr
 - [Lower Level Examples](#lower-level-examples)
   - [Extracting `txInfoInputs` from `ScriptContext` manually (UNTYPED)](#extracting-txinfoinputs-from-scriptcontext-manually-untyped)
 - [Useful Links](#useful-links)
+- [How to build docs](#how-to-build-docs)
 
 </details>
 
@@ -289,3 +290,17 @@ There's just one element in `txInfoInputs` in this example, and there it is. Of 
 - [Plutus builtin functions and types](https://playground.plutus.iohkdev.io/doc/haddock//plutus-tx/html/PlutusTx-Builtins-Internal.html)
 - [Plutus Core builtin function identifiers, aka `DefaultFun`](https://playground.plutus.iohkdev.io/doc/haddock/plutus-core/html/PlutusCore.html#t:DefaultFun)
 - [Plutus Core types, aka `DefaultUni`](https://playground.plutus.iohkdev.io/doc/haddock/plutus-core/html/PlutusCore.html#t:DefaultUni)
+
+# How to build docs
+
+To run the docs locally,
+
+```sh-session
+nix run .#docs
+```
+
+To build the static HTML site,
+
+```sh-session
+nix build .#website
+```

--- a/docs/Introduction/Plutarch Types.md
+++ b/docs/Introduction/Plutarch Types.md
@@ -2,7 +2,7 @@
 
 When this guide uses the term "Plutarch Type" we explicitly talk about a type of _kind_ `PType`. We will refer to  _" types of kind `PType` "_ simply as `PType`s. We explicitly qualify when referring to the _kind_ `PType`.
 
-> Note to beginners: Plutarch uses a language extension called `DataKinds`. This means that there are kinds beyond `Type` (aka `*`). We refer the read to \[[3](./../Concepts.md#references)] for an extended beginner-level introduction to these concepts if desired.
+> Note to beginners: Plutarch uses a language extension called `DataKinds`. This means that there are kinds beyond `Type` (aka `*`). We refer the read to \[[3](./../Introduction.md#references)] for an extended beginner-level introduction to these concepts if desired.
 
 `PType` is defined as `type PType = S -> Type`; that is, it is a _kind synonym_ for `S -> Type` (where `S` and `Type` are themselves kinds). This synonym is important to keep in mind because when querying the kind of something like `PBool` in, say, GHCi, we will _not_ see `PType` as the kind. Instead, we get
 

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -44,7 +44,7 @@ f = phoistAcyclic $ plam $ \n ->
 
 The issue here is that the AST is infinitely large. Plutarch will try to traverse this AST and will in the process not terminate, as there is no end to it. In these cases, consider using `pfix`.
 
-Relevant issue: [#19](https://github.com/Plutonomicon/plutarch/issues/19)
+Relevant issue: [\#19](https://github.com/Plutonomicon/plutarch/issues/19)
 
 # Couldn't match type `Plutarch.DataRepr.Internal.PUnLabel ...` arising from a use of `pfield` (or `hrecField`, or `pletFields`)
 
@@ -68,7 +68,7 @@ Orphan instances! Specifically, in order for those type family applications to f
 
 This happens often with Plutarch ledger API types. If you didn't import `Plutarch.Api.V1.Contexts` (or some other module that imports it), and you're using `pconstant` on a `ScriptContext` - you'll get an error like this. The `PConstant` instance for `ScriptContext` hasn't been imported - so GHC has no idea what `PConstanted ScriptContext` is!
 
-Relevant issue: [#252](https://github.com/Plutonomicon/plutarch/issues/252)
+Relevant issue: [\#252](https://github.com/Plutonomicon/plutarch/issues/252)
 
 # Type match errors when using `pfield`/`hrecField` (or `OverloadedRecordDot` to access field)
 
@@ -76,4 +76,4 @@ You might get nonsensical "Couldn't match type" errors when extracting fields. T
 
 You can fix this by providing an explicit type annotation on _the result_ of `pfield` or `hrecField` (or `OverloadedRecordDot` for field access). Otherwise, you can also explicitly use `pfromData` on the result.
 
-Relevant issue: [#275](https://github.com/Plutonomicon/plutarch/issues/275)
+Relevant issue: [\#275](https://github.com/Plutonomicon/plutarch/issues/275)

--- a/docs/Typeclasses/PConstant and PLift.md
+++ b/docs/Typeclasses/PConstant and PLift.md
@@ -214,4 +214,4 @@ deriving via
     PConstant (Maybe h)
 ```
 
-Relevant issue: [#286](https://github.com/Plutonomicon/plutarch/issues/286)
+Relevant issue: [\#286](https://github.com/Plutonomicon/plutarch/issues/286)

--- a/docs/Typeclasses/PIsDataRepr and PDataFields.md
+++ b/docs/Typeclasses/PIsDataRepr and PDataFields.md
@@ -105,7 +105,7 @@ mockCtx =
 Right (Program () (Version () 1 0 0) (Constant () (Some (ValueOf string "It's minting!"))))
 ```
 
-> Aside: You can find the definition of `evalWithArgsT` at [Compiling and Running](../GUIDE.md#compiling-and-running).
+> Aside: You can find the definition of `evalWithArgsT` at [Compiling and Running](../README.md#compiling-and-running).
 
 ## All about extracting fields
 

--- a/docs/examples/BASIC.md
+++ b/docs/examples/BASIC.md
@@ -2,7 +2,7 @@ Basic examples demonstrating Plutarch usage.
 
 > Note: If you spot any mistakes/have any related questions that this guide lacks the answer to, please don't hesitate to raise an issue. The goal is to have high quality documentation for Plutarch users!
 
-> Aside: Be sure to check out [Compiling and Running](./../GUIDE.md#compiling-and-running) first!
+> Aside: Be sure to check out [Compiling and Running](./../README.md#compiling-and-running) first!
 
 # Fibonacci number at given index
 

--- a/docs/examples/VALIDATOR.md
+++ b/docs/examples/VALIDATOR.md
@@ -7,7 +7,7 @@ Examples of validators and minting policies written in Plutarch.
 - [Validator that checks whether a value is present within signatories](#validator-that-checks-whether-a-value-is-present-within-signatories)
 - [Using custom datum/redeemer in your Validator](#using-custom-datumredeemer-in-your-validator)
 
-> Aside: Be sure to check out [Compiling and Running](./../GUIDE.md#compiling-and-running) first!
+> Aside: Be sure to check out [Compiling and Running](./../README.md#compiling-and-running) first!
 
 # Validator that always succeeds
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,3 @@
+# Plutarch
+
+See [[README]]

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,3 @@
-# Plutarch
+# Plutarch Guide
 
 See [[README]]

--- a/docs/index.yaml
+++ b/docs/index.yaml
@@ -6,6 +6,7 @@
 template:
   # Change this to 'pretty' to use URLs without .html suffix.
   urlStrategy: direct
+  theme: green
 
 page:
   siteTitle: Plutarch Guide

--- a/docs/index.yaml
+++ b/docs/index.yaml
@@ -5,9 +5,3 @@ page:
   siteTitle: Plutarch
   headHtml: |
     <snippet var="js.prism" />
-
-pandoc:
-  rewriteClass:
-    # For use in notes with Prism.JS disabled (specifically code-block using
-    # pages like Mermaid)
-    code-block: border-2 p-1 overflow-auto my-1 bg-gray-50

--- a/docs/index.yaml
+++ b/docs/index.yaml
@@ -1,7 +1,13 @@
+# Emanote settings
+#
+# For list of possible settings and their defaults, see: 
+# https://github.com/srid/emanote/blob/master/default/index.yaml
+
 template:
+  # Change this to 'pretty' to use URLs without .html suffix.
   urlStrategy: direct
 
 page:
-  siteTitle: Plutarch
+  siteTitle: Plutarch Guide
   headHtml: |
     <snippet var="js.prism" />

--- a/docs/index.yaml
+++ b/docs/index.yaml
@@ -1,0 +1,13 @@
+template:
+  urlStrategy: direct
+
+page:
+  siteTitle: Plutarch
+  headHtml: |
+    <snippet var="js.prism" />
+
+pandoc:
+  rewriteClass:
+    # For use in notes with Prism.JS disabled (specifically code-block using
+    # pages like Mermaid)
+    code-block: border-2 p-1 overflow-auto my-1 bg-gray-50

--- a/flake.lock
+++ b/flake.lock
@@ -245,16 +245,16 @@
         "unionmount": "unionmount"
       },
       "locked": {
-        "lastModified": 1648155826,
-        "narHash": "sha256-GzgtVRMZxMInUSyDPd/wD7P47BBU5OqBvbhvH6QqbKs=",
+        "lastModified": 1648167902,
+        "narHash": "sha256-wtGOpbO8kW7TFeTEWOvc3zPzVNFzKaYLfQaoIjwv/KI=",
         "owner": "srid",
         "repo": "emanote",
-        "rev": "59480123fdf2f70c9ed0d898b8b120661546a83c",
+        "rev": "7e488a5057ac863ed8fea8665829ac74a36d3c03",
         "type": "github"
       },
       "original": {
         "owner": "srid",
-        "ref": "rel-link-and-anchors",
+        "ref": "master",
         "repo": "emanote",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -245,11 +245,11 @@
         "unionmount": "unionmount"
       },
       "locked": {
-        "lastModified": 1648152050,
-        "narHash": "sha256-Gily4oO2hmrrYui/WZBr45r3+huSmyvUAhkFEMtcrDM=",
+        "lastModified": 1648153867,
+        "narHash": "sha256-em+49tMCjGskzSxBIfSJYxKaA032xU/6SggwyRJdPUE=",
         "owner": "srid",
         "repo": "emanote",
-        "rev": "1b70424d750ff83cc3104573d7dc7e99300150d5",
+        "rev": "6044d819594f1aca593a0fdacbd6168782804336",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -199,6 +199,66 @@
         "type": "github"
       }
     },
+    "ema": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "pre-commit-hooks": "pre-commit-hooks"
+      },
+      "locked": {
+        "lastModified": 1648150821,
+        "narHash": "sha256-AGwZRHD2Gcn2kuT3FQCaQOoBhH1D+Blk0WXuEXWyr2c=",
+        "owner": "srid",
+        "repo": "ema",
+        "rev": "624bcd5103e847fbbb9c59e39dab507424dd8299",
+        "type": "github"
+      },
+      "original": {
+        "owner": "srid",
+        "ref": "multisite",
+        "repo": "ema",
+        "type": "github"
+      }
+    },
+    "emanote": {
+      "inputs": {
+        "ema": "ema",
+        "flake-compat": [
+          "emanote",
+          "ema",
+          "flake-compat"
+        ],
+        "flake-utils": [
+          "emanote",
+          "ema",
+          "flake-utils"
+        ],
+        "heist": "heist",
+        "nixpkgs": [
+          "emanote",
+          "ema",
+          "nixpkgs"
+        ],
+        "pathtree": "pathtree",
+        "tailwind-haskell": "tailwind-haskell",
+        "unionmount": "unionmount"
+      },
+      "locked": {
+        "lastModified": 1648152050,
+        "narHash": "sha256-Gily4oO2hmrrYui/WZBr45r3+huSmyvUAhkFEMtcrDM=",
+        "owner": "srid",
+        "repo": "emanote",
+        "rev": "1b70424d750ff83cc3104573d7dc7e99300150d5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "srid",
+        "ref": "rel-link-and-anchors",
+        "repo": "emanote",
+        "type": "github"
+      }
+    },
     "flake-compat": {
       "flake": false,
       "locked": {
@@ -233,6 +293,54 @@
     "flake-compat_2": {
       "flake": false,
       "locked": {
+        "lastModified": 1641205782,
+        "narHash": "sha256-4jY7RCWUoZ9cKD8co0/4tFARpWB+57+r1bLLvXNJliY=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "b7547d3eed6f32d06102ead8991ec52ab0a4f1a7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1627913399,
+        "narHash": "sha256-hY8g6H2KFL8ownSiFeMOjwPC8P0ueXpCVEbxgda3pko=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "12c64ca55c1014cdc1b16ed5a804aa8576601ff2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_4": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1641205782,
+        "narHash": "sha256-4jY7RCWUoZ9cKD8co0/4tFARpWB+57+r1bLLvXNJliY=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "b7547d3eed6f32d06102ead8991ec52ab0a4f1a7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_5": {
+      "flake": false,
+      "locked": {
         "lastModified": 1606424373,
         "narHash": "sha256-oq8d4//CJOrVj+EcOaSXvMebvuTkmBJuT5tzlfewUnQ=",
         "owner": "edolstra",
@@ -247,7 +355,7 @@
         "type": "github"
       }
     },
-    "flake-compat_3": {
+    "flake-compat_6": {
       "flake": false,
       "locked": {
         "lastModified": 1606424373,
@@ -264,6 +372,66 @@
       }
     },
     "flake-utils": {
+      "locked": {
+        "lastModified": 1644229661,
+        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "locked": {
+        "lastModified": 1619345332,
+        "narHash": "sha256-qHnQkEp1uklKTpx3MvKtY6xzgcqXDsz5nLilbbuL+3A=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "2ebf2558e5bf978c7fb8ea927dfaed8fefab2e28",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_3": {
+      "locked": {
+        "lastModified": 1642700792,
+        "narHash": "sha256-XqHrk7hFb+zBvRg6Ghl+AZDq03ov6OshJLiSWOoX5es=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "846b2ae0fc4cc943637d3d1def4454213e203cba",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_4": {
+      "locked": {
+        "lastModified": 1631561581,
+        "narHash": "sha256-3VQMV5zvxaVLvqqUrNz3iJelLw30mIVSfZmAaauM3dA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "7e5bf3925f6fbdfaf50a2a7ca0be2879c4261d19",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_5": {
       "locked": {
         "lastModified": 1644229661,
         "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
@@ -417,7 +585,7 @@
         "cabal-34": "cabal-34",
         "cabal-36": "cabal-36",
         "cardano-shell": "cardano-shell",
-        "flake-utils": "flake-utils",
+        "flake-utils": "flake-utils_5",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk",
         "hackage": "hackage",
         "hpc-coveralls": "hpc-coveralls",
@@ -464,9 +632,26 @@
         "type": "github"
       }
     },
+    "heist": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1624205223,
+        "narHash": "sha256-+bcrEKjB/kDRAqOunCD/cKBBVOJUTmY9RoCQ++I42oM=",
+        "owner": "srid",
+        "repo": "heist",
+        "rev": "a8be6f93656f87199e03b9dfb9979dc061614108",
+        "type": "github"
+      },
+      "original": {
+        "owner": "srid",
+        "ref": "emanote",
+        "repo": "heist",
+        "type": "github"
+      }
+    },
     "hercules-ci-agent": {
       "inputs": {
-        "flake-compat": "flake-compat_3",
+        "flake-compat": "flake-compat_6",
         "nix-darwin": "nix-darwin",
         "nixos-20_09": "nixos-20_09",
         "nixos-unstable": "nixos-unstable",
@@ -489,9 +674,9 @@
     },
     "hercules-ci-effects": {
       "inputs": {
-        "flake-compat": "flake-compat_2",
+        "flake-compat": "flake-compat_5",
         "hercules-ci-agent": "hercules-ci-agent",
-        "nixpkgs": "nixpkgs_2",
+        "nixpkgs": "nixpkgs_4",
         "nixpkgs-nixops": "nixpkgs-nixops"
       },
       "locked": {
@@ -575,7 +760,7 @@
     },
     "nix-darwin": {
       "inputs": {
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs_3"
       },
       "locked": {
         "lastModified": 1622060422,
@@ -641,16 +826,18 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1602411953,
-        "narHash": "sha256-gbupmxRpoQZqL5NBQCJN2GI5G7XDEHHHYKhVwEj5+Ps=",
-        "owner": "LnL7",
+        "lastModified": 1647350163,
+        "narHash": "sha256-OcMI+PFEHTONthXuEQNddt16Ml7qGvanL3x8QOl2Aao=",
+        "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "f780534ea2d0c12e62607ff254b6b45f46653f7a",
+        "rev": "3eb07eeafb52bcbf02ce800f032f18d666a9498d",
         "type": "github"
       },
       "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "3eb07eeafb52bcbf02ce800f032f18d666a9498d",
+        "type": "github"
       }
     },
     "nixpkgs-2003": {
@@ -735,6 +922,34 @@
     },
     "nixpkgs_2": {
       "locked": {
+        "lastModified": 1645655918,
+        "narHash": "sha256-ZfbEFRW7o237+A1P7eTKhXje435FCAoe0blj2n20Was=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "77a7a4197740213879b9a1d2e1788c6c8ade4274",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_3": {
+      "locked": {
+        "lastModified": 1602411953,
+        "narHash": "sha256-gbupmxRpoQZqL5NBQCJN2GI5G7XDEHHHYKhVwEj5+Ps=",
+        "owner": "LnL7",
+        "repo": "nixpkgs",
+        "rev": "f780534ea2d0c12e62607ff254b6b45f46653f7a",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_4": {
+      "locked": {
         "lastModified": 1633463774,
         "narHash": "sha256-y3GjapcRzd42NgebQ4sx5GFJ53dYqNdF3UQu7/t6mUg=",
         "owner": "hercules-ci",
@@ -749,7 +964,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_3": {
+    "nixpkgs_5": {
       "flake": false,
       "locked": {
         "lastModified": 1628785280,
@@ -783,6 +998,30 @@
         "type": "github"
       }
     },
+    "pathtree": {
+      "inputs": {
+        "flake-compat": "flake-compat_2",
+        "flake-utils": "flake-utils_3",
+        "nixpkgs": [
+          "emanote",
+          "ema",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1647644631,
+        "narHash": "sha256-aRuyBXjUrva7RNSWIIbB+HefowF8wZepCkkaCDm8Qn4=",
+        "owner": "srid",
+        "repo": "pathtree",
+        "rev": "8619aada5b0cd76dff37a2e90b47eecbb3fb7d23",
+        "type": "github"
+      },
+      "original": {
+        "owner": "srid",
+        "repo": "pathtree",
+        "type": "github"
+      }
+    },
     "plutus": {
       "inputs": {
         "cardano-repo-tool": "cardano-repo-tool",
@@ -791,7 +1030,7 @@
         "haskell-language-server": "haskell-language-server_2",
         "haskell-nix": "haskell-nix_2",
         "iohk-nix": "iohk-nix_2",
-        "nixpkgs": "nixpkgs_3",
+        "nixpkgs": "nixpkgs_5",
         "pre-commit-hooks-nix": "pre-commit-hooks-nix_2",
         "sphinxcontrib-haddock": "sphinxcontrib-haddock",
         "stackage-nix": "stackage-nix"
@@ -808,6 +1047,25 @@
         "owner": "L-as",
         "ref": "ghc9",
         "repo": "plutus",
+        "type": "github"
+      }
+    },
+    "pre-commit-hooks": {
+      "inputs": {
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1646153636,
+        "narHash": "sha256-AlWHMzK+xJ1mG267FdT8dCq/HvLCA6jwmx2ZUy5O8tY=",
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "b6bc0b21e1617e2b07d8205e7fae7224036dfa4b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
         "type": "github"
       }
     },
@@ -868,7 +1126,8 @@
         "cardano-crypto": "cardano-crypto",
         "cardano-prelude": "cardano-prelude",
         "cryptonite": "cryptonite",
-        "flake-compat": "flake-compat",
+        "emanote": "emanote",
+        "flake-compat": "flake-compat_4",
         "flake-compat-ci": "flake-compat-ci",
         "flat": "flat",
         "foundation": "foundation",
@@ -989,6 +1248,39 @@
         "type": "github"
       }
     },
+    "tailwind-haskell": {
+      "inputs": {
+        "flake-compat": [
+          "emanote",
+          "ema",
+          "flake-compat"
+        ],
+        "flake-utils": [
+          "emanote",
+          "ema",
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "emanote",
+          "ema",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1647792199,
+        "narHash": "sha256-QndGcDf2ySiA+1CSo05lSE9qBCcV18hBCgw8qH9PfEo=",
+        "owner": "srid",
+        "repo": "tailwind-haskell",
+        "rev": "9deb377835f9035a658c694dd82cb772afeb2d36",
+        "type": "github"
+      },
+      "original": {
+        "owner": "srid",
+        "ref": "master",
+        "repo": "tailwind-haskell",
+        "type": "github"
+      }
+    },
     "th-extras": {
       "flake": false,
       "locked": {
@@ -1003,6 +1295,31 @@
         "owner": "mokus0",
         "repo": "th-extras",
         "rev": "787ed752c1e5d41b5903b74e171ed087de38bffa",
+        "type": "github"
+      }
+    },
+    "unionmount": {
+      "inputs": {
+        "flake-compat": "flake-compat_3",
+        "flake-utils": "flake-utils_4",
+        "nixpkgs": [
+          "emanote",
+          "ema",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1647795307,
+        "narHash": "sha256-olb4o0+l8XXtdQ8NKLtwjI5A9/4CPMgRdBVtZVvsLlY=",
+        "owner": "srid",
+        "repo": "unionmount",
+        "rev": "ccd5049de67bfd7f042deda00a41659ec4e36f3c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "srid",
+        "ref": "master",
+        "repo": "unionmount",
         "type": "github"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -245,11 +245,11 @@
         "unionmount": "unionmount"
       },
       "locked": {
-        "lastModified": 1648217348,
-        "narHash": "sha256-aIi7o8V+9NBYBe6eig1KrA/iKrZavd7rfiqm09lAVFs=",
+        "lastModified": 1648225238,
+        "narHash": "sha256-aDQNIpiAAnM5j8oFdvxQzpBCv7JyW4uZgWKLwdZBRCQ=",
         "owner": "srid",
         "repo": "emanote",
-        "rev": "2863f214c20a024d13cae0976016974759d92633",
+        "rev": "cce3558d2d142a95ea39099e7b3b2e930b2f3a61",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -245,11 +245,11 @@
         "unionmount": "unionmount"
       },
       "locked": {
-        "lastModified": 1648167902,
-        "narHash": "sha256-wtGOpbO8kW7TFeTEWOvc3zPzVNFzKaYLfQaoIjwv/KI=",
+        "lastModified": 1648217348,
+        "narHash": "sha256-aIi7o8V+9NBYBe6eig1KrA/iKrZavd7rfiqm09lAVFs=",
         "owner": "srid",
         "repo": "emanote",
-        "rev": "7e488a5057ac863ed8fea8665829ac74a36d3c03",
+        "rev": "2863f214c20a024d13cae0976016974759d92633",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -245,11 +245,11 @@
         "unionmount": "unionmount"
       },
       "locked": {
-        "lastModified": 1648153867,
-        "narHash": "sha256-em+49tMCjGskzSxBIfSJYxKaA032xU/6SggwyRJdPUE=",
+        "lastModified": 1648155826,
+        "narHash": "sha256-GzgtVRMZxMInUSyDPd/wD7P47BBU5OqBvbhvH6QqbKs=",
         "owner": "srid",
         "repo": "emanote",
-        "rev": "6044d819594f1aca593a0fdacbd6168782804336",
+        "rev": "59480123fdf2f70c9ed0d898b8b120661546a83c",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -57,6 +57,9 @@
   inputs.autodocodec.url = "github:srid/autodocodec/ghc921";
   inputs.autodocodec.flake = false;
 
+  inputs.emanote.url = "github:srid/emanote/rel-link-and-anchors";
+  # inputs.emanote.inputs.ema.inputs.nixpkgs.follows = "nixpkgs";
+
   outputs = inputs@{ self, nixpkgs, iohk-nix, haskell-nix, plutus, flake-compat, flake-compat-ci, hercules-ci-effects, ... }:
     let
       extraSources = [
@@ -666,6 +669,16 @@
           test-ghc9-dev = plutarchTestApp system "ghc9-dev" self.projectMatrix.ghc9.dev;
           test-ghc810-nodev = plutarchTestApp system "ghc810-nodev" self.projectMatrix.ghc810.nodev;
           test-ghc810-dev = plutarchTestApp system "ghc810-dev" self.projectMatrix.ghc810.dev;
+          docs  = rec {
+            type = "app";
+            # '' is required for escaping ${} in nix
+            script = (nixpkgsFor system).writers.writeBash "emanoteLiveReload.sh" ''
+              set -xe
+              export PORT="''${EMANOTE_PORT:-7072}"
+              ${inputs.emanote.defaultPackage.${system}}/bin/emanote --layers ./docs run --port "$PORT"
+            '';
+            program = builtins.toString script;
+          };
         }
       );
       devShell = perSystem (system: self.flake.${system}.devShell);

--- a/flake.nix
+++ b/flake.nix
@@ -58,7 +58,6 @@
   inputs.autodocodec.flake = false;
 
   inputs.emanote.url = "github:srid/emanote/rel-link-and-anchors";
-  # inputs.emanote.inputs.ema.inputs.nixpkgs.follows = "nixpkgs";
 
   outputs = inputs@{ self, nixpkgs, iohk-nix, haskell-nix, plutus, flake-compat, flake-compat-ci, hercules-ci-effects, ... }:
     let

--- a/flake.nix
+++ b/flake.nix
@@ -57,7 +57,7 @@
   inputs.autodocodec.url = "github:srid/autodocodec/ghc921";
   inputs.autodocodec.flake = false;
 
-  inputs.emanote.url = "github:srid/emanote/rel-link-and-anchors";
+  inputs.emanote.url = "github:srid/emanote/master";
 
   outputs = inputs@{ self, nixpkgs, iohk-nix, haskell-nix, plutus, flake-compat, flake-compat-ci, hercules-ci-effects, ... }:
     let

--- a/flake.nix
+++ b/flake.nix
@@ -589,7 +589,7 @@
         let
           pkgs = nixpkgsFor system;
           configFile = (pkgs.formats.yaml { }).generate "emanote-configFile" {
-            template.baseUrl = "/plutarch/";
+            template.baseUrl = "/"; # Use this when pushing to github.io: "/plutarch/";
           };
           configDir = pkgs.runCommand "emanote-configDir" { } ''
             mkdir -p $out


### PR DESCRIPTION
Adds `nix run .#docs` to run a live web view of docs locally. As well as `nix run .#website` to build the static website. This is the same as what we do in https://github.com/Plutonomicon/plutonomicon - but using a newer version of Emanote containing support for the [full range of relative links](https://github.com/srid/emanote/pull/268).

The latter command also checks for broken links (the CI for this PR succeeds because those broken links have been fixed here).

Eventually, we can include Haddock generated HTML in the generated site of `nix run .#website`, before deploying it statically to GH pages using #393.

