### PR TITLE
Add `bin/ghcid`

### DIFF
--- a/bin/ghcid
+++ b/bin/ghcid
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+set -xe
+
+if [[ $1 == "" ]]
+then
+  echo "Running ghcid on plutarch"
+  ghcid
+elif [[ $1 == "extra" ]]
+then
+  echo "Running ghcid on plutarch-extra"
+  ghcid -c 'cabal repl plutarch-extra:lib:plutarch-extra'
+elif [[ $1 == "test:dev" ]]
+then
+  echo "Running ghcid on plutarch-test in development mode"
+  ghcid -c 'cabal repl plutarch-test:exe:plutarch-test -f development --builddir=dist-ghc9-dev' -T Main.main
+elif [[ $1 == "test" ]]
+then
+  echo "Running ghcid on plutarch-test in non-development mode"
+  ghcid -c 'cabal repl plutarch-test:exe:plutarch-test' -T Main.main
+else
+  echo "Invalid argument"
+  exit 2
+fi

--- a/plutarch-test/README.md
+++ b/plutarch-test/README.md
@@ -13,13 +13,13 @@ $ nix run .#test-ghc810-nodev
 To run the tests using ghcid (fit for writing tests):
 
 ```sh-session
-$ ghcid -c 'cabal repl plutarch-test:exe:plutarch-test' -T Main.main
+bin/ghcid test
 ```
 
 To run ghcid with development flag set:
 
 ```sh-session
-$ ghcid -c 'cabal repl plutarch-test:exe:plutarch-test -f development --builddir=dist-ghc9-dev' -T Main.main
+bin/ghcid test:dev
 ```
 
 Note: `cabal run` should be run inside `./plutarch-test` directory.


### PR DESCRIPTION
Instead of having to copy-paste the ghcid command from `plutarch-test/README.md`, this enables us to just run `bin/ghcid <arg>`. The script also provides two more cases for running ghcid on the packages (plutarch and plutarch-extra) in the repo.

Alternate approach: We could add a function alias in nix-shell to run these ghcid commands. That's not however great for discoverability; but, one idea is to display the aliases available in `shellHook` ([eg](https://github.com/NorfairKing/feedback/commit/8cc1a0efaaad034ed28a346742216a4f82d74d01)).