### PR TITLE
`plutarch-test`: Avoid evaluating the test tree twice

### DIFF
--- a/plutarch-test/Main.hs
+++ b/plutarch-test/Main.hs
@@ -8,24 +8,26 @@ import qualified ExtraSpec
 #if MIN_VERSION_GLASGOW_HASKELL(9,0,0,0)
 import qualified Plutarch.FieldSpec as FieldSpec
 import qualified Plutarch.MonadicSpec as MonadicSpec
-import Plutarch.Test.Run (noUnusedGoldens)
+import Plutarch.Test.Run (noUnusedGoldens, hspecAndReturnForest)
+import Test.Hspec (Spec, describe)
 #else
 import qualified Plutarch.FFISpec as FFISpec
+import Test.Hspec (Spec, describe, hspec)
 #endif
 
 import GHC.IO.Encoding (setLocaleEncoding, utf8)
-import Test.Hspec (Spec, describe, hspec)
 
 main :: IO ()
 main = do
   setLocaleEncoding utf8
-  hspec spec
 
 -- We test for unused goldens, but do so only in GHC 9. Because, under GHC 8
 -- certain modules are disabled (see the CPP below) which leads to legitimately
 -- unused goldens detected leading to false positive in test failure.
 #if MIN_VERSION_GLASGOW_HASKELL(9,0,0,0)
-  noUnusedGoldens spec
+  noUnusedGoldens =<< hspecAndReturnForest spec
+#else
+  hspec spec
 #endif
 
 spec :: Spec

--- a/plutarch-test/common/Plutarch/Test.hs
+++ b/plutarch-test/common/Plutarch/Test.hs
@@ -26,8 +26,6 @@ module Plutarch.Test (
   (@==),
   pgoldenSpec,
   pgoldenSpec',
-  noUnusedGoldens,
-  noUnusedGoldens',
   PlutarchGoldens,
   GoldenConf (..),
   GoldenTest (..),
@@ -35,6 +33,10 @@ module Plutarch.Test (
   -- * Benchmark type for use in `(@:->)`
   Benchmark (Benchmark, exBudgetCPU, exBudgetMemory, scriptSizeBytes),
   ScriptSizeBytes,
+
+  -- * Test runner related utilities
+  noUnusedGoldens,
+  noUnusedGoldens',
 ) where
 
 import Data.Text (Text)


### PR DESCRIPTION
- Add `hspecAndReturnForest` based on https://github.com/hspec/hspec/issues/649#issuecomment-1092423220
- Change `noUnusedGoldens` to take the test tree directly, preventing it from evaluating the spec (a second time, unnecessarily)