### PR TITLE
Add some `HRec` utility types and `TermCont` functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -153,6 +153,22 @@
 
   Added by: [#345](https://github.com/Plutonomicon/plutarch/pull/345)
 
+- Add `HRecOf`, `PMemberFields`, and `PMemberField` utility types.
+
+  Module: `Plutarch.DataRepr`.
+
+  Added by: [#466](https://github.com/Plutonomicon/plutarch/pull/466)
+
+- Move `Plutarch.ListUtils` to `Plutarch.Extra.List`.
+
+  Added by: [#466](https://github.com/Plutonomicon/plutarch/pull/466)
+
+- Add various `TermCont` utilities: `ptraceC`, `pletFieldsC`, `ptryFromC`, `pguardC`, and `pguardC'`.
+
+  Module: `Plutarch.Extra.TermCont`.
+
+  Added by: [#466](https://github.com/Plutonomicon/plutarch/pull/466)
+
 # 1.1.0
 
 - General repository changes.

--- a/Plutarch/DataRepr.hs
+++ b/Plutarch/DataRepr.hs
@@ -23,6 +23,7 @@ module Plutarch.DataRepr (
   F.pletFields,
   F.pfield,
   F.HRec,
+  F.HRecOf,
 ) where
 
 import qualified Plutarch.DataRepr.Internal as I

--- a/Plutarch/DataRepr.hs
+++ b/Plutarch/DataRepr.hs
@@ -24,6 +24,8 @@ module Plutarch.DataRepr (
   F.pfield,
   F.HRec,
   F.HRecOf,
+  F.PMemberFields,
+  F.PMemberField,
 ) where
 
 import qualified Plutarch.DataRepr.Internal as I

--- a/Plutarch/DataRepr/Internal.hs
+++ b/Plutarch/DataRepr/Internal.hs
@@ -18,6 +18,7 @@ module Plutarch.DataRepr.Internal (
   PLabeledType (..),
   type PLabelIndex,
   type PUnLabel,
+  type PLookupLabel,
   PIsDataRepr (..),
   PIsDataReprInstances (..),
   pindexDataRecord,
@@ -247,6 +248,11 @@ type family PDataRecordFields2 as where
 type family PLabelIndex (name :: Symbol) (as :: [PLabeledType]) :: Nat where
   PLabelIndex name ((name ':= a) ': as) = 0
   PLabelIndex name (_ ': as) = (PLabelIndex name as) + 1
+
+type PLookupLabel :: Symbol -> [PLabeledType] -> PType
+type family PLookupLabel name as where
+  PLookupLabel name ((name ':= a) ': as) = a
+  PLookupLabel name (_ ': as) = PLookupLabel name as
 
 type family PUnLabel (a :: PLabeledType) :: PType where
   PUnLabel (name ':= a) = a

--- a/Plutarch/DataRepr/Internal/Field.hs
+++ b/Plutarch/DataRepr/Internal/Field.hs
@@ -9,6 +9,7 @@ module Plutarch.DataRepr.Internal.Field (
 
   -- * BindFields class mechanism
   BindFields (..),
+  type Bindings,
   type BoundTerms,
   type Drop,
 

--- a/Plutarch/DataRepr/Internal/Field.hs
+++ b/Plutarch/DataRepr/Internal/Field.hs
@@ -12,6 +12,7 @@ module Plutarch.DataRepr.Internal.Field (
   type Bindings,
   type BoundTerms,
   type Drop,
+  type HRecOf,
 
   -- * Re-exports
   HRec (..),
@@ -113,6 +114,15 @@ instance
   type PFields (PAsData a) = PFields a
   ptoFields = ptoFields . pfromData
 
+-- | The 'HRec' yielded by 'pletFields @fs t'.
+type HRecOf t fs s =
+  HRec
+    ( BoundTerms
+        (PFields t)
+        (Bindings (PFields t) fs)
+        s
+    )
+
 {- |
   Bind a HRec of named fields containing all the specified
   fields.
@@ -125,7 +135,7 @@ pletFields ::
   , BindFields ps bs
   ) =>
   Term s a ->
-  (HRec (BoundTerms ps bs s) -> Term s b) ->
+  (HRecOf a fs s -> Term s b) ->
   Term s b
 pletFields t =
   runTermCont $

--- a/docs/README.md
+++ b/docs/README.md
@@ -139,6 +139,7 @@ Outside of the fundamental user guide, there are rules of thumb and general guid
 - [Prefer statically building constants whenever possible](./Tricks/Prefer%20statically%20building%20constants.md)
 - [Figuring out the representation of a Plutarch type](./Tricks/Representation%20of%20Plutarch%20type.md)
 - [Prefer pattern matching on the result of `pmatch` immediately](./Tricks/Prefer%20matching%20on%20pmatch%20result%20immediately.md)
+- [Working with bound fields yielded by `pletFields`](./Tricks/Working%20with%20bound%20fields.md)
 
 # Common Issues and Troubleshooting
 

--- a/docs/Tricks.md
+++ b/docs/Tricks.md
@@ -13,3 +13,4 @@ This document discusses various rules of thumb and general trivia, aiming to mak
 - [Prefer statically building constants whenever possible](./Tricks/Prefer%20statically%20building%20constants.md)
 - [Figuring out the representation of a Plutarch type](./Tricks/Representation%20of%20Plutarch%20type.md)
 - [Prefer pattern matching on the result of `pmatch` immediately](./Tricks/Prefer%20matching%20on%20pmatch%20result%20immediately.md)
+- [Working with bound fields yielded by `pletFields`](./Tricks/Working%20with%20bound%20fields.md)

--- a/docs/Tricks/Working with bound fields.md
+++ b/docs/Tricks/Working with bound fields.md
@@ -1,0 +1,77 @@
+# Working with bound fields yielded by `pletFields`
+
+You may have noticed that `pletFields` actually returns a Haskell level heterogenous list, with all the interesting fields "bound" to it. Only the fields you actually use from these bindings are extracted and put into the resulting script. Therefore, you _only pay for what you use_.
+
+```hs
+pletFields ::
+  forall fs a s b ps bs.
+  ( PDataFields a
+  , ps ~ (PFields a)
+  , bs ~ (Bindings ps fs)
+  , BindFields ps bs
+  ) =>
+  Term s a ->
+  (HRecOf a fs s -> Term s b) ->
+  Term s b
+```
+
+The real juice of that massive type is the `HRecOf`, which is a utility type alias you can use in functions that operate on the return value of `pletFields`:
+
+```hs
+import qualified GHC.Generics as GHC
+import Generics.SOP
+
+import Plutarch.Prelude
+import Plutarch.DataRepr
+
+newtype PFooType s = PFooType (Term s (PDataRecord '["frst" ':= PInteger, "scnd" ':= PBool, "thrd" ':= PString]))
+  deriving stock (GHC.Generic)
+  deriving anyclass (Generic)
+  deriving anyclass (PIsDataRepr)
+  deriving
+    (PlutusType, PIsData, PDataFields, PEq)
+    via PIsDataReprInstances PFooType
+
+foo :: HRecOf PFooType '["scnd", "frst"] s -> Term s PInteger
+foo h = pif (getField @"scnd" h) (getField @"frst" h) 0
+```
+
+This is very useful for single use functions that you use as "branches" in your validators - they work more like macros or templates rather than real functions. For example, you might have different branches for different constructors of a redeemer, but all branches end up needing to do common field extraction. You could abstract it out using:
+
+```hs
+firstRedmCheck :: HRecOf PTxInfo '["inputs", "outputs", "mint", "datums"] s -> TermCont s (Term s PUnit)
+firstRedmCheck info = do
+  -- Do checks with info fields here.
+  pure $ pconstant ()
+
+secondRedmCheck : HRecOf PTxInfo '["inputs", "outputs", "mint", "datums"] s -> TermCont s (Term s PUnit)
+secondRedmCheck info = do
+  -- Do checks with info fields here.
+  pure $ pconstant ()
+
+coreValidator = plam $ \_ redm ctx' -> unTermCont $ do
+  ctx <- tcont $ pletFields @'["txInfo", "purpose"] ctx'
+  info <- tcont $ pletFields @'["inputs", "outputs", "mint", "datums"] $ getField @"txInfo" ctx
+  pmatchC redm >>= \case
+    FirstRedm _ -> firstRedmCheck info
+    SecondRedm _ -> secondRedmCheck info
+```
+
+Without it, you may have to fallback to deconstructing `info` with `pletFields` in every single branch.
+
+However, this is rather _nominal_. What if you don't need the exact same fields in all branches? Let's go back to the example with `foo` and `FooType`. What if someone has:
+
+```hs
+fooTypeHrec <- tcont $ pletFields @'["frst", "scnd", "thrd"] fooTypeValue
+foo fooTypeHrec
+-- uh oh
+```
+
+The type required by `foo` should _morally_ work just fine with `fooTypeHrec`, but it won't! What we really want, is some sort of row polymorphism. This is where the `PMemberFields` type from `Plutarch.DataRepr` comes in:
+
+```hs
+foo :: PMemberFields PFooType '["scnd", "frst"] s as => HRec as -> Term s PInteger
+foo h = pif (getField @"scnd" h) (getField @"frst" h) 0
+```
+
+Now `foo` merely requires the `HRec` to have the `"scnd"` and `"frst"` fields from `PFooType`, more fields are allowed just fine!

--- a/plutarch-extra/Plutarch/Extra/List.hs
+++ b/plutarch-extra/Plutarch/Extra/List.hs
@@ -1,4 +1,4 @@
-module Plutarch.ListUtils (preverse, pcheckSorted) where
+module Plutarch.Extra.List (preverse, pcheckSorted) where
 
 import Plutarch.Prelude
 

--- a/plutarch-extra/Plutarch/Extra/TermCont.hs
+++ b/plutarch-extra/Plutarch/Extra/TermCont.hs
@@ -1,13 +1,21 @@
-{- | TermCont-related adapters for Plutarch functions.
+{-# LANGUAGE AllowAmbiguousTypes #-}
 
-  TODO: More functions (pletFieldsC, ptraceC, ...) need to be added here.
--}
+-- | TermCont-related adapters for Plutarch functions.
 module Plutarch.Extra.TermCont (
   pletC,
   pmatchC,
+  pletFieldsC,
+  ptraceC,
+  pguardC,
+  pguardC',
+  ptryFromC,
 ) where
 
+import Plutarch.DataRepr
+import Plutarch.DataRepr.Internal.Field
 import Plutarch.Prelude
+import Plutarch.Reducible
+import Plutarch.TryFrom
 
 -- | Like `plet` but works in a `TermCont` monad
 pletC :: Term s a -> TermCont s (Term s a)
@@ -16,3 +24,61 @@ pletC = tcont . plet
 -- | Like `pmatch` but works in a `TermCont` monad
 pmatchC :: PMatch a => Term s a -> TermCont s (a s)
 pmatchC = tcont . pmatch
+
+-- | Like `pletFields` but works in a `TermCont` monad.
+pletFieldsC ::
+  forall fs a s b ps bs.
+  ( PDataFields a
+  , ps ~ PFields a
+  , bs ~ Bindings ps fs
+  , BindFields ps bs
+  ) =>
+  Term s a ->
+  TermCont @b s (HRec (BoundTerms ps bs s))
+pletFieldsC x = tcont $ pletFields @fs x
+
+{- | Like `ptrace` but works in a `TermCont` monad.
+
+=== Example ===
+
+@
+foo :: Term s PUnit
+foo = unTermCont $ do
+  ptraceC "returning unit!"
+  pure $ pconstant ()
+@
+-}
+ptraceC :: Term s PString -> TermCont s ()
+ptraceC s = tcont $ \f -> ptrace s (f ())
+
+{- | Trace a message and raise error if 'cond' is false. Otherwise, continue.
+
+=== Example ===
+
+@
+onlyAllow42 :: Term s (PInteger :--> PUnit)
+onlyAllow42 = plam $ \i -> unTermCont $ do
+  pguardC "expected 42" $ i #== 42
+  pure $ pconstant ()
+@
+-}
+pguardC :: Term s PString -> Term s PBool -> TermCont s ()
+pguardC s cond = tcont $ \f -> pif cond (f ()) $ ptraceError s
+
+{- | Stop computation and return given term if 'cond' is false. Otherwise, continue.
+
+=== Example ===
+
+@
+is42 :: Term s (PInteger :--> PBool)
+is42 = plam $ \i -> unTermCont $ do
+  pguardC "expected 42" (pconstant False) $ i #== 42
+  pure $ pconstant True
+@
+-}
+pguardC' :: Term s a -> Term s PBool -> TermCont @a s ()
+pguardC' r cond = tcont $ \f -> pif cond (f ()) r
+
+-- | 'TermCont' producing version of 'ptryFrom'.
+ptryFromC :: forall b r a s. PTryFrom a b => Term s a -> TermCont @r s (Term s b, Reduce (PTryFromExcess a b s))
+ptryFromC = tcont . ptryFrom

--- a/plutarch-extra/Plutarch/Extra/TermCont.hs
+++ b/plutarch-extra/Plutarch/Extra/TermCont.hs
@@ -11,11 +11,15 @@ module Plutarch.Extra.TermCont (
   ptryFromC,
 ) where
 
-import Plutarch.DataRepr
-import Plutarch.DataRepr.Internal.Field
+import Plutarch.DataRepr (HRec, PDataFields, PFields)
+import Plutarch.DataRepr.Internal.Field (
+  BindFields,
+  Bindings,
+  BoundTerms,
+ )
 import Plutarch.Prelude
-import Plutarch.Reducible
-import Plutarch.TryFrom
+import Plutarch.Reducible (Reduce)
+import Plutarch.TryFrom (PTryFromExcess)
 
 -- | Like `plet` but works in a `TermCont` monad
 pletC :: Term s a -> TermCont s (Term s a)

--- a/plutarch-extra/plutarch-extra.cabal
+++ b/plutarch-extra/plutarch-extra.cabal
@@ -82,6 +82,6 @@ library
     Plutarch.Extra
     Plutarch.Extra.Api
     Plutarch.Extra.TermCont
-    Plutarch.ListUtils
+    Plutarch.Extra.List
 
 -- other-modules:

--- a/plutarch-extra/plutarch-extra.cabal
+++ b/plutarch-extra/plutarch-extra.cabal
@@ -81,7 +81,7 @@ library
   exposed-modules:
     Plutarch.Extra
     Plutarch.Extra.Api
-    Plutarch.Extra.TermCont
     Plutarch.Extra.List
+    Plutarch.Extra.TermCont
 
 -- other-modules:

--- a/plutarch-test/common/Plutarch/Test.hs
+++ b/plutarch-test/common/Plutarch/Test.hs
@@ -37,6 +37,7 @@ module Plutarch.Test (
   -- * Test runner related utilities
   noUnusedGoldens,
   noUnusedGoldens',
+  hspecAndReturnForest,
 ) where
 
 import Data.Text (Text)
@@ -61,7 +62,7 @@ import Plutarch.Test.Golden (
   (@\),
   (@|),
  )
-import Plutarch.Test.Run (noUnusedGoldens, noUnusedGoldens')
+import Plutarch.Test.Run (hspecAndReturnForest, noUnusedGoldens, noUnusedGoldens')
 import qualified Plutus.V1.Ledger.Scripts as Scripts
 import Test.Hspec (Expectation, Spec, describe, expectationFailure, shouldBe, shouldSatisfy)
 import Test.Tasty.HUnit (assertFailure)

--- a/plutarch-test/plutarch-extra/Plutarch/Extra/ListSpec.hs
+++ b/plutarch-test/plutarch-extra/Plutarch/Extra/ListSpec.hs
@@ -1,6 +1,6 @@
-module Plutarch.ListUtilsSpec (spec) where
+module Plutarch.Extra.ListSpec (spec) where
 
-import Plutarch.ListUtils (pcheckSorted, preverse)
+import Plutarch.Extra.List (pcheckSorted, preverse)
 import Plutarch.Prelude
 
 import Hedgehog (Property)

--- a/plutarch-test/plutarch-test.cabal
+++ b/plutarch-test/plutarch-test.cabal
@@ -156,10 +156,10 @@ executable plutarch-test
     Plutarch.ByteStringSpec
     Plutarch.EitherSpec
     Plutarch.Extra.ApiSpec
+    Plutarch.Extra.ListSpec
     Plutarch.IntegerSpec
     Plutarch.LiftSpec
     Plutarch.ListSpec
-    Plutarch.ListUtilsSpec
     Plutarch.MaybeSpec
     Plutarch.PairSpec
     Plutarch.PIsDataSpec


### PR DESCRIPTION
* Some handy utilities for working with `pletFields` returned `HRec`. See [guide section](https://github.com/Plutonomicon/plutarch/blob/some-exports/docs/Tricks/Working%20with%20bound%20fields.md).
* Move `Plutarch.ListUtils` to `Plutarch.Extra.List`, following the existing `plutarch-extra` module naming convention.
* Upstream a bunch of common `TermCont` utilities that I've been using throughout my projects.
* Export `hspecAndReturnForest` (useful for user projects utilizing `noUnusedGoldens`)