### PR TITLE
Fix some typos in docs and add `PIsData` constraint to `PConstantData` to `PLiftData` aliases

### DIFF
--- a/Plutarch/DataRepr/Internal.hs
+++ b/Plutarch/DataRepr/Internal.hs
@@ -600,8 +600,9 @@ Polymorphic types can be derived as follows:
 type PConstantData :: Type -> Constraint
 type PConstantData h =
   ( PConstant h
-  , Ledger.FromData (h)
-  , Ledger.ToData (h)
+  , Ledger.FromData h
+  , Ledger.ToData h
+  , PIsData (PConstanted h)
   )
 
 type PLiftData :: PType -> Constraint
@@ -609,6 +610,7 @@ type PLiftData p =
   ( PLift p
   , Ledger.FromData (PLifted p)
   , Ledger.ToData (PLifted p)
+  , PIsData p
   )
 
 {- |

--- a/Plutarch/Lift.hs
+++ b/Plutarch/Lift.hs
@@ -62,8 +62,8 @@ This typeclass is closely tied with 'PLift'.
 Laws:
  - @pconstantFromRepr . pconstantToRepr ≡ Just@
  - @(pconstantToRepr <$>) . pconstantFromRepr ≡ Just@
- - @plift . pfromData . punsafeCoerce . pconstant . toData ≡ id@
- - @fromData . plift . pforgetData . ptoData . pconstant ≡ Just@
+ - @plift . pfromData . punsafeCoerce . pconstant . PlutusTx.toData ≡ id@
+ - @PlutusTx.fromData . plift . pforgetData . pdata . pconstant ≡ Just@
 
 These laws must be upheld for the sake of soundness of the type system.
 -}

--- a/docs/Typeclasses/PIsDataRepr and PDataFields.md
+++ b/docs/Typeclasses/PIsDataRepr and PDataFields.md
@@ -16,7 +16,7 @@ import qualified Plutarch.Monadic as P
 
 foo :: Term s (PScriptContext :--> PString)
 foo = plam $ \ctx -> P.do
-  purpose <- pmatch pfield @"purpose" # ctx
+  purpose <- pmatch $ pfield @"purpose" # ctx
   case purpose of
     PMinting _ -> "It's minting!"
     PSpending _ -> "It's spending!"
@@ -247,7 +247,7 @@ Thus, you can use `PBuiltinList (PAsData PInteger)` as a field type, but not `PB
 > In this case, `PFourWheeler` is at the 0th index, `PTwoWheeler` is at the 1st index, and `PImmovableBox` is at the 3rd index. Thus, the corresponding `makeIsDataIndexed` usage should be:
 >
 > ```hs
-> PlutusTx.makeIsDataIndexed ''FourWheeler [('FourWheeler,0),('TwoWheeler,1),('ImmovableBox,2)]
+> PlutusTx.makeIsDataIndexed ''PVehicle [('FourWheeler,0),('TwoWheeler,1),('ImmovableBox,2)]
 > ```
 >
 > Also see: [Isomorphism between Haskell ADTs and `PIsDataRepr`](./../Tricks/makeIsDataIndexed,%20Haskell%20ADTs,%20and%20PIsDataRepr.md)


### PR DESCRIPTION
Resolves #468 

Also fixed the `PLift` laws referencing incorrect function names.