### PR TITLE
minor typo fix

### DIFF
--- a/docs/Typeclasses/PConstant and PLift.md
+++ b/docs/Typeclasses/PConstant and PLift.md
@@ -139,7 +139,7 @@ Finally, we have `DerivePConstantViaData` for `Data` values:
 ```hs
 {-# LANGUAGE UndecidableInstances #-}
 
-import Plutarch.Lift (DerivePConstantViaNewtype (DerivePConstantViaNewtype))
+import Plutarch.Lift (DerivePConstantViaData (DerivePConstantViaData))
 import Plutarch.Prelude
 
 import qualified Plutus.V1.Ledger.Api as Plutus


### PR DESCRIPTION
Minor typo where it was importing DerivePConstantViaNewtype instead of DerivePConstantViaData for the DerivePConstantViaData example.